### PR TITLE
feat: Disable redundant import rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindoktor/eslint-config",
-  "version": "1.1.0-0",
+  "version": "1.1.0-1",
   "type": "module",
   "description": "Shared ESLint config for MinDoktor projects",
   "repository": "git@github.com:mindoktor/eslint-config.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindoktor/eslint-config",
-  "version": "1.0.3",
+  "version": "1.1.0-0",
   "type": "module",
   "description": "Shared ESLint config for MinDoktor projects",
   "repository": "git@github.com:mindoktor/eslint-config.git",

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-named-as-default-member */
 import eslint from '@eslint/js';
 import importPlugin from 'eslint-plugin-import';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
@@ -78,6 +77,15 @@ export const mindoktorRecommended = tseslint.config(
       'import/no-named-default': 'error',
       'import/no-self-import': 'error',
       'import/no-webpack-loader-syntax': 'error',
+      // Disable redundant rules
+      // See more:
+      // - Performance issues: https://typescript-eslint.io/troubleshooting/typed-linting/performance#eslint-plugin-import
+      // - Parse errors: https://github.com/typescript-eslint/typescript-eslint/issues/1333
+      'import/named': 'off',
+      'import/namespace': 'off',
+      'import/default': 'off',
+      'import/no-named-as-default-member': 'off',
+      'import/no-unresolved': 'off',
     },
   },
   {

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -80,10 +80,10 @@ export const mindoktorRecommended = tseslint.config(
       // See more:
       // - Performance issues: https://typescript-eslint.io/troubleshooting/typed-linting/performance#eslint-plugin-import
       // - Parse errors: https://github.com/typescript-eslint/typescript-eslint/issues/1333
-      'import/no-deprecated': 'off',
+      'import/default': 'off',
       'import/named': 'off',
       'import/namespace': 'off',
-      'import/default': 'off',
+      'import/no-deprecated': 'off',
       'import/no-named-as-default-member': 'off',
       'import/no-unresolved': 'off',
     },

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -72,7 +72,6 @@ export const mindoktorRecommended = tseslint.config(
       'import/no-absolute-path': 'error',
       'import/no-amd': 'error',
       'import/no-cycle': 'warn',
-      'import/no-deprecated': 'warn',
       'import/no-extraneous-dependencies': 'error',
       'import/no-named-default': 'error',
       'import/no-self-import': 'error',
@@ -81,6 +80,7 @@ export const mindoktorRecommended = tseslint.config(
       // See more:
       // - Performance issues: https://typescript-eslint.io/troubleshooting/typed-linting/performance#eslint-plugin-import
       // - Parse errors: https://github.com/typescript-eslint/typescript-eslint/issues/1333
+      'import/no-deprecated': 'off',
       'import/named': 'off',
       'import/namespace': 'off',
       'import/default': 'off',


### PR DESCRIPTION
## JIRA issues
https://mdinternational.atlassian.net/browse/MDP-8361
<!-- For example: https://mdinternational.atlassian.net/browse/ABC-123 -->

## Background (why)
While enabling this for the mindoktor-app, I got issue like https://github.com/typescript-eslint/typescript-eslint/issues/1333, which lead me to discover that some of the recommended rules are [redundant when using typescript and incur an unnecessary performance penalties](https://typescript-eslint.io/troubleshooting/typed-linting/performance#eslint-plugin-import).
<!-- Describe the background or the context why the change is being implemented -->
<!-- For example: We have noticed user accounts are created with empty emails -->

## Changes (how)
 - Disable redundant rules
<!-- Describe how the changes were implemented -->
<!-- For example: Backend now throws an error to the front end if the email is empty -->

## How has this been tested?
 - linting on mindoktor-app
<!-- How did you test the change? -->

## Screenshots
NA
<!-- Add screenshots if it's appropriate for the reviewers -->
