### PR TITLE
fix: Add workaround for type-import issues with no-duplicate-imports rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindoktor/eslint-config",
-  "version": "2.0.0",
+  "version": "2.0.1-0",
   "type": "module",
   "description": "Shared ESLint config for MinDoktor projects",
   "repository": "git@github.com:mindoktor/eslint-config.git",

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -89,6 +89,15 @@ export const mindoktorRecommended = defineConfig(
       'import/no-unresolved': 'off',
     },
   },
+  // Type import workaround for no-duplicate-imports issues
+  // See more: https://github.com/import-js/eslint-plugin-import/issues/3185#issuecomment-3275581648
+  {
+    rules: {
+      'import/no-duplicates': ['off'],
+      'no-duplicate-imports': ['error', { allowSeparateTypeImports: true }],
+    },
+  },
+  // Import sorting and unused imports
   {
     plugins: {
       'simple-import-sort': simpleImportSort,


### PR DESCRIPTION
## JIRA issues
https://mdinternational.atlassian.net/browse/MDP-8718
<!-- For example: https://mdinternational.atlassian.net/browse/ABC-123 -->

## Background (why)
While developing we notices some autofix lead to syntax and runtime errors. Also reported to the plugin authors: https://github.com/import-js/eslint-plugin-import/issues/3185#issuecomment-3275581648
<!-- Describe the background or the context why the change is being implemented -->
<!-- For example: We have noticed user accounts are created with empty emails -->

## Changes (how)
 - Workaround the issue and use [no-duplicate-imports](https://eslint.org/docs/latest/rules/no-duplicate-imports) instead of [import/no-duplicates ](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md)
<!-- Describe how the changes were implemented -->
<!-- For example: Backend now throws an error to the front end if the email is empty -->

## How has this been tested?
[On CLINIC_APP](https://github.com/mindoktor/mindoktor/pull/18569)
<!-- How did you test the change? -->

## Screenshots
NA
<!-- Add screenshots if it's appropriate for the reviewers -->
