### PR TITLE
chore: Change lint extends order to fix rules not being applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import { globalIgnores, defineConfig } from 'eslint/config';
 
 const defaultConfig = defineConfig(
   {
-    extends: [configs.recommended, configs.stylistic],
+    extends: [configs.stylistic, configs.recommended],
     languageOptions: {
       parserOptions: {
         projectService: true,
@@ -81,7 +81,7 @@ import { globalIgnores, defineConfig } from 'eslint/config';
 
 const defaultConfig = defineConfig(
   {
-    extends: [configs.reactRecommended, configs.stylistic],
+    extends: [configs.stylistic, configs.reactRecommended],
     languageOptions: {
       parserOptions: {
         projectService: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export const configs = {
 };
 
 const defaultConfig = defineConfig({
-  extends: [mindoktorRecommended, mindoktorStylistic],
+  extends: [mindoktorStylistic, mindoktorRecommended],
 });
 
 export default defaultConfig;


### PR DESCRIPTION
## JIRA issues

<!-- For example: https://mdinternational.atlassian.net/browse/ABC-123 -->

N/A

## Background (why)

<!-- Describe the background or the context why the change is being implemented -->
<!-- For example: We have noticed user accounts are created with empty emails -->

I found out some eslint rules weren't being applied, like `curly`. It seems this was overridden by the mindoktor stylistic package (prettier). So in order to have our rules being applied correctly, lets change the order they're applied.

## Changes (how)

<!-- Describe how the changes were implemented -->
<!-- For example: Backend now throws an error to the front end if the email is empty -->

- Change lint extends order to fix rules not being applied.

## How has this been tested?

<!-- How did you test the change? -->

Lcoally.

## Screenshots

<!-- Add screenshots if it's appropriate for the reviewers -->
