### PR TITLE
feat: enforce separate-line type imports

### DIFF
--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -80,6 +80,11 @@ export const mindoktorRecommended = defineConfig(
     rules: {
       'import/enforce-node-protocol-usage': ['error', 'always'],
       'import/export': 'error',
+      // Enforce separate-line type imports over the inline `type` keyword on
+      // value imports. consistent-type-imports only marks type imports as types;
+      // it treats inline (`import { type X }`) and top-level (`import type { X }`)
+      // as equally valid. This rule requires the top-level form for cleaner erasure.
+      'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
       'import/first': 'error',
       'import/newline-after-import': 'error',
       'import/no-absolute-path': 'error',


### PR DESCRIPTION
## JIRA issues

https://mdinternational.atlassian.net/browse/MDP-11181

## Background (why)

`@typescript-eslint/consistent-type-imports` only ensures type-only imports are *marked* as types. It treats the inline form (`import { type X }`) and the top-level form (`import type { X }`) as equally valid, so it never enforces the separate-line style we prefer for cleaner type erasure.

The ticket suggested fixing this with `fixStyle: "separate-type-imports"` on that rule. That would not have worked: `separate-type-imports` is already the rule's default, and `fixStyle` only controls how the autofixer *rewrites* — it does not turn the inline form into a violation. The rule that actually reports the inline keyword is `import/consistent-type-specifier-style` set to `prefer-top-level`, which is what this PR adds.

## Changes (how)

- Add `import/consistent-type-specifier-style: ['error', 'prefer-top-level']` to the recommended config's import rules. `consistent-type-imports` is left unchanged — the two are complementary (one marks type imports, the new one enforces placement).

What the new rule forbids vs. requires:

```ts
// ✗ Forbidden from now on — inline `type` keyword on a mixed import
import { makeValue, type Theme } from './theme';

// ✗ Forbidden — inline `type` even when every specifier is type-only
import { type Style, type Theme } from './theme';

// ✓ Required — type-only imports on their own top-level line
import type { Theme } from './theme';
import { makeValue } from './theme';

// ✓ Required — a purely type-only import uses the top-level form
import type { Style, Theme } from './theme';
```

`eslint --fix` performs this rewrite automatically, and the result stays clean against the existing `no-duplicate-imports` (`allowSeparateTypeImports: true`) and `simple-import-sort` rules.

## How has this been tested?

Verified locally against the installed `@typescript-eslint` (v8.42.0) and `eslint-plugin-import`:

- Before: `import { value, type X }` passed with zero errors.
- After: the inline forms above are flagged (`Prefer using a top-level type-only import instead of inline type specifiers`), and `--fix` produces the required forms without conflicting with `no-duplicate-imports` or `simple-import-sort`.
- `yarn lint`, `yarn typecheck`, and `yarn build` all pass. This repo's own source had no inline type imports to migrate.

## Screenshots

N/A

## Note on the "migrate all existing files" acceptance criterion

This repo *is* the shared config, so there is nothing to migrate here. The actual file migration happens in the **consumer repos** (clinic-app, patient-app, etc.) when they bump `@mindoktor/eslint-config` and run `eslint --fix`. Because this is a rule tightening — the calling contract is unchanged and consumers can override the rule to `warn`/`off` — it should ship as a **minor** version bump, consistent with #11 (which also added `error`-level rules as a minor).

## Checklist

- [ ] I checked whether this change affects any agent skills and ran `/tool-md-maintain-skills` if needed
