### PR TITLE
chore: add .claude agent skills and instruction files

### DIFF
--- a/.claude/skills/ref-md-agents-auto-approve/SKILL.md
+++ b/.claude/skills/ref-md-agents-auto-approve/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: ref-md-agents-auto-approve
+description: >-
+  Decide which terminal commands are safe to auto-approve (run unattended)
+  versus which must always prompt. Use when: configuring
+  chat.tools.terminal.autoApprove or Claude Code permissions, adding an
+  allowlist entry, reducing how often the agent stops to ask ("stop prompting
+  me for this", "let it run without asking"), or judging whether a
+  git/gh/yarn/jira-cli command can run without confirmation. Core principle:
+  reading is safe, writing and
+  destructive actions always ask. Covers the read-vs-write classification,
+  the security exceptions, regex pattern gotchas, and a never-auto-approve list.
+metadata:
+  author: mindoktor
+  version: "1.3"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "agents"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+  shareable-skills.requires: "ref-md-agents-security"
+  shareable-skills.reason: "The classification and example patterns target this org's stack (yarn, uv run jira-cli, gh); each repo keeps its actual allowlist in its own settings."
+---
+
+# Agent Auto-Approve Policy
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+Guidance for deciding which terminal commands an agent harness may run **without
+prompting the user**, and which must always require explicit confirmation.
+
+## Guiding Principle
+
+> **Reading is safe to auto-approve. Writing, editing, and destructive actions always ask.**
+
+A command qualifies for auto-approval only when it **observes** state without
+changing it: listing, viewing, diffing, searching, checking status. Anything that
+**mutates** state — the filesystem, git history, a remote, a tracker, the machine
+— must prompt, every time.
+
+When in doubt, **do not auto-approve.** A prompt costs a click; an unattended
+destructive command costs recovery work or worse.
+
+## The Security Exception — Some Reads Are Still Not Safe
+
+"Reading is safe" has one hard carve-out: **reads that conflict with
+`ref-md-agents-security` are never
+auto-approved**, because they can expose secrets even though they only "read."
+
+| Never auto-approve (even though it reads)                              | Why                                                      |
+| ---------------------------------------------------------------------- | -------------------------------------------------------- |
+| `cat .env`, `head .env.local`, `grep TOKEN .env*`                      | Reads credential files — forbidden by the security skill |
+| `printenv`, `env`, `echo $TOKEN`, `set`                                | Dumps environment variables, exposing secret values      |
+| `gh api` / `curl` returning secret-bearing payloads                    | Response body can surface tokens into transcripts        |
+| Reading `credentials.json`, `*.pem`, `*.key`, `serviceAccountKey.json` | Secret material — forbidden by the security skill        |
+
+The security skill's prohibitions **override** this skill. If a read touches
+secrets, treat it as forbidden, not as a safe read.
+
+## How to Classify a Command
+
+| Step | What                                                                      | Why                                                           | When                                 |
+| ---- | ------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------ |
+| 1    | Identify the verb's effect: observe vs mutate                             | Mutation is the dividing line                                 | Every classification                 |
+| 2    | If it can expose secrets, stop — it is forbidden, not safe                | Security overrides read-safety                                | Any command touching env/credentials |
+| 3    | Check the **flags**, not just the subcommand                              | Flags flip safe verbs into destructive ones (`git branch -D`) | Any command with options             |
+| 4    | Prefer **whitelisting** the safe form over blacklisting the dangerous one | A blacklist misses forms you did not predict                  | When writing a regex pattern         |
+| 5    | If any branch of the command can write, exclude the whole command         | Partial safety is not safety                                  | Compound or flag-variable commands   |
+
+## Example Read-Safe Allowlist (and Why)
+
+An illustrative set of read-safe patterns, shown in VS Code
+`chat.tools.terminal.autoApprove` regex form — the same classification applies
+to Claude Code `permissions.allow` rules. A repo's **actual** allowlist lives in
+that repo's own config (`.vscode/settings.json` or `.claude/settings.json`);
+use this table as the reference for what a well-scoped entry looks like:
+
+| Pattern                                                                                      | What it allows                       | Safe because                                              |
+| -------------------------------------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------- |
+| `^yarn typecheck$`                                                                           | Type checking                        | Read-only analysis                                        |
+| `^yarn lint( --quiet)?$`                                                                     | Linting                              | Read-only analysis                                        |
+| `^yarn test( .*)?$`                                                                          | Test runs                            | Tests do not mutate tracked state                         |
+| `^git (diff\|log\|show\|status)( .*)?$`                                                      | Inspect history, changes, and status | Pure reads                                                |
+| `^git branch( -(a\|r\|v+\|av+\|rv+)\| --(show-current\|all\|remotes\|verbose\|list))?$`      | List branches                        | **Whitelisted flags only** — excludes `-d`/`-D`/`-m`/`-M` |
+| `^gh (pr (view\|list\|checks\|diff\|status)\|issue (view\|list))( .*)?$`                     | Read PRs/issues + comments           | Read-only GitHub queries                                  |
+| `^gh api (?!.* (-X\|--method\|-f\|-F\|--field\|--raw-field\|--input)).*$`                    | Pure GET API calls                   | Excludes any method override or body/field flag           |
+| `^uv run .* jira-cli (issue (view\|list)\|sprint list\|board list\|project list\|me)( .*)?$` | Read Jira tasks/comments             | Read-only jira-cli subcommands                            |
+
+## Pattern Gotchas
+
+Lessons that make a "read-only" pattern leak into write territory:
+
+| Gotcha                              | What goes wrong                                                                    | Fix                                                                            |
+| ----------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| **`gh api` field flags imply POST** | `gh api repos/o/r/issues -f title=x` writes without `-X`/`--method` ever appearing | Exclude `-f`/`-F`/`--field`/`--raw-field`/`--input` too                        |
+| **Glued short flags**               | `gh api -XPOST ...` bypasses a pattern that only matches `-X POST` (with a space)  | Match the flag token without requiring a following space                       |
+| **`git branch` is dual-purpose**    | `-d`/`-D` delete, `-m`/`-M` rename — destructive                                   | Whitelist only the read flags; never use an open `git branch .*`               |
+| **Blacklist blind spots**           | Listing forbidden verbs misses synonyms and new flags                              | Whitelist the safe form; reject everything else by default                     |
+| **`matchCommandLine`**              | Without it, only the program name is matched, ignoring args/flags                  | Set `"matchCommandLine": true` so the whole line is evaluated                  |
+| **Compound commands**               | `git log && rm -rf x` reads then destroys                                          | Anchor patterns with `^...$`; reject `&&`, `;`, `\|` to files, `>` redirection |
+
+## Never Auto-Approve
+
+Always prompt for these — they mutate state or run untrusted code:
+
+- **Git writes/destructive**: `git commit`, `push`, `reset`, `rebase`, `merge`,
+  `checkout`/`switch`, `branch -d`/`-D`/`-m`/`-M`, `clean`, `stash drop`,
+  `tag -d`, `cherry-pick`, `revert`, `restore`.
+- **GitHub writes**: `gh pr create`/`merge`/`close`/`edit`/`comment`/`review`,
+  `gh issue create`/`close`/`comment`, `gh api` with `-X`/`--method` or any
+  field/input flag, `gh release create`, `gh repo delete`.
+- **Jira writes**: `jira-cli` `create`, `edit`, `transition`, `assign`,
+  `comment add`, or any mutating subcommand.
+- **Filesystem destructive**: `rm`, `mv`, `cp` over existing files, `>`/`>>`
+  redirection into tracked files, `truncate`, `chmod`/`chown` at scale.
+- **Installs**: any package manager install (`yarn add`, `npm install`,
+  `brew install`, `pip install`, `uv add`, …) — including **bare `yarn`**,
+  which defaults to `yarn install` and runs postinstall scripts — forbidden
+  without explicit approval per `ref-md-agents-security`.
+- **Anything touching secrets**: see the security exception above.
+
+## Where This Is Enforced
+
+Auto-approval is a **harness/client feature**, configured per agent client.
+The behavioral judgment in this skill is the source of truth; the config is the
+mechanism.
+
+| Agent client          | Mechanism                                                           | Location                |
+| --------------------- | ------------------------------------------------------------------- | ----------------------- |
+| **Copilot / VS Code** | `chat.tools.terminal.autoApprove` regex map with `matchCommandLine` | `.vscode/settings.json` |
+| **Claude Code**       | `permissions.allow` / `permissions.deny` tool patterns              | `.claude/settings.json` |
+
+When adding an entry, document *why* it is read-safe (mirror the table above) so
+the next reviewer can audit the allowlist quickly.
+
+## Related Skills
+
+| Skill                    | When to load                                                               |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `ref-md-agents-security` | Secrets, `.env` files, installs — the overriding exceptions to read-safety |

--- a/.claude/skills/ref-md-agents-hooks/SKILL.md
+++ b/.claude/skills/ref-md-agents-hooks/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: ref-md-agents-hooks
+description: >-
+  What agent hooks are, how to write effective ones, and the event models for
+  Claude Code / Agent SDK, GitHub Copilot CLI, and Gemini CLI. Use when:
+  implementing tool-call interception, automating an action on every tool call,
+  edit, or commit ("run lint after every edit", "from now on do X whenever Y"),
+  session lifecycle automation, context injection, blocking dangerous
+  operations, audit logging, or forwarding a notification when the agent
+  finishes or needs input — on any of the three platforms. Covers the shared execution
+  model (synchronous, JSON in/out, matchers, exit codes, security), a
+  cross-platform event comparison table, and per-platform references for
+  Claude Code CLI, Agent SDK (TypeScript/Python), GitHub Copilot, and
+  Gemini CLI.
+metadata:
+  author: mindoktor
+  version: "1.6"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "agents"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+---
+
+# Agent Hooks
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+Hooks are shell commands (or SDK callback functions) that execute automatically at defined points in an agent's lifecycle — before/after a tool call, at session boundaries, when a subagent starts, and more. They let you block dangerous operations, inject context, log every action, modify tool arguments, or relay notifications to external services — without changing the agent's core prompt or model.
+
+All three platforms share the same core model: **synchronous execution by default, JSON in/out, matchers to narrow which events fire**. They differ in available event types, handler kinds, and configuration format.
+
+## Routing Table
+
+| Topic                                                                                                                  | Read                                                         |
+| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Shared concepts — execution model, universal event categories, matchers, exit codes, writing effective hooks, security | [`references/hooks-shared.md`](references/hooks-shared.md)   |
+| Claude Code CLI (settings.json) + Agent SDK callback hooks (Python/TypeScript)                                         | [`references/hooks-claude.md`](references/hooks-claude.md)   |
+| GitHub Copilot CLI (`.github/hooks/`) + cloud agent                                                                    | [`references/hooks-copilot.md`](references/hooks-copilot.md) |
+| Gemini CLI (`.gemini/settings.json`)                                                                                   | [`references/hooks-gemini.md`](references/hooks-gemini.md)   |
+
+## Event Cross-Reference
+
+| Concept                             | Claude Code / SDK   | GitHub Copilot      | Gemini CLI            |
+| ----------------------------------- | ------------------- | ------------------- | --------------------- |
+| Before tool (blocking, fail-closed) | `PreToolUse`        | `preToolUse`        | `BeforeTool`          |
+| After tool (success)                | `PostToolUse`       | `postToolUse`       | `AfterTool`           |
+| Session start                       | `SessionStart`      | `sessionStart`      | `SessionStart`        |
+| Session end                         | `SessionEnd`        | `sessionEnd`        | `SessionEnd`          |
+| Subagent start                      | `SubagentStart`     | `subagentStart`     | —                     |
+| Subagent stop                       | `SubagentStop`      | `subagentStop`      | —                     |
+| Agent turn complete                 | `Stop`              | `agentStop`         | `AfterAgent`          |
+| Notification                        | `Notification`      | `notification`      | —                     |
+| Before model call                   | —                   | —                   | `BeforeModel`         |
+| After model call                    | —                   | —                   | `AfterModel`          |
+| Before tool selection               | —                   | —                   | `BeforeToolSelection` |
+| Agent loop start                    | —                   | —                   | `BeforeAgent`         |
+| Permission dialog                   | `PermissionRequest` | `permissionRequest` | —                     |
+| Context compaction                  | `PreCompact`        | `preCompact`        | `PreCompress`         |
+
+## Pattern: pre-write skill-load reminder
+
+A recurring miss: an agent edits code in a stack area (e.g. a React component under `CLINIC_APP/**`) without loading the matching `ref-md-*` skill, then drifts from a convention the skill documents but CI does not enforce. A `PreToolUse` hook matching `Edit`/`Write` can close it — inspect the target path against a path → skill map and, when it matches a stack area, inject a reminder to load that skill (non-blocking, exit 0 with context) or block until acknowledged (fail-closed, exit 2).
+
+```jsonc
+// path → skill map the hook script owns, e.g.
+// CLINIC_APP/**            → ref-md-js-react, ref-md-js-tanstack-query, ref-md-js-mui, ref-md-dev-coding-patterns
+// **/*.go                  → ref-md-go-golang, ref-md-go-tests
+```
+
+This is the **highest-guarantee, highest-noise** enforcement option, and it is **opt-in per consumer repo**, not shipped here — a shared skill cannot register a `settings.json` hook (see the `agentic-tools hooks` installer in the `agentic-tools` repo's `AGENTS.md`). Weigh it against review being the current safety net before wiring it: a blocking variant that fires on every edit under a broad glob generates friction and false positives. The advisory instruction-index alternative (a load-skill *precondition* in the repo's `AGENTS.md`) is documented in `ref-md-agents-skills-authoring`; the convention the loaded skill then enforces is in `ref-md-dev-coding-patterns` (documented convention beats local imitation).
+
+## Related Skills
+
+| Skill                            | When to load                                                                     |
+| -------------------------------- | -------------------------------------------------------------------------------- |
+| `ref-md-agents-auto-approve`     | Which Claude Code tool calls are safe to auto-approve via hooks                  |
+| `ref-md-agents-security`         | Security rules when hooks handle env vars, secrets, or user-supplied data        |
+| `ref-md-agents-skills-authoring` | The advisory load-skill precondition, the softer alternative to a pre-write hook |
+| `ref-md-dev-coding-patterns`     | The convention a loaded skill enforces (documented convention beats imitation)   |

--- a/.claude/skills/ref-md-agents-hooks/references/hooks-claude.md
+++ b/.claude/skills/ref-md-agents-hooks/references/hooks-claude.md
@@ -1,0 +1,398 @@
+# Hooks — Claude Code CLI + Agent SDK
+
+Two interfaces share the same event names and JSON schema but differ in how hooks are registered and what languages are supported:
+
+| Interface                         | Where hooks live        | Handler format                                                            |
+| --------------------------------- | ----------------------- | ------------------------------------------------------------------------- |
+| **Claude Code CLI**               | `settings.json` files   | Shell commands, HTTP endpoints, MCP tool calls, LLM prompts, or subagents |
+| **Agent SDK (TypeScript/Python)** | `options.hooks` in code | Async callback functions — no shell spawned                               |
+
+---
+
+## A. Claude Code CLI — Shell Command Hooks
+
+### Configuration Files & Load Order
+
+| Location                                                                                                                   | Scope                                                                                                     |
+| -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `/Library/Application Support/ClaudeCode/managed-settings.json` (macOS) / `/etc/claude-code/managed-settings.json` (Linux) | Organization policy — loaded first; cannot be disabled by `disableAllHooks`; requires elevated privileges |
+| `~/.claude/settings.json`                                                                                                  | All projects for this user                                                                                |
+| `.claude/settings.json`                                                                                                    | This project (commit to share)                                                                            |
+| `.claude/settings.local.json`                                                                                              | This project (gitignored)                                                                                 |
+| Plugin `hooks/hooks.json`                                                                                                  | While the plugin is enabled                                                                               |
+
+Resolution order: managed policy → user → project → local → plugin. All matching hooks for an event run; policy hooks cannot be overridden by project settings.
+
+> **Installing a hook from a source repo — symlink for `~/.claude`, copy for a
+> project.** When you export a hook script into the user location
+> (`~/.claude/hooks/`), **symlink** it to the source repo — exactly like skills
+> are symlinked into `~/.claude/skills/` — so edits to the source stay live and
+> the installed copy can't silently drift. Only **copy** when vendoring into a
+> separate project that is committed and cloned on other machines, where an
+> absolute symlink back to the source repo could not resolve. The `command` path
+> in `settings.json` is unaffected either way — it points at the same location;
+> only the file behind it (link vs copy) differs.
+
+### JSON Structure
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/check.sh",
+            "if": "Bash(rm *)",
+            "timeout": 30,
+            "statusMessage": "Running safety check…"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Event Reference
+
+| Event                 | Blocks                | Fires when                                           |
+| --------------------- | --------------------- | ---------------------------------------------------- |
+| `SessionStart`        | No                    | Session begins or resumes                            |
+| `Setup`               | No                    | Launched with `--init-only` / `--maintenance`        |
+| `SessionEnd`          | No                    | Session terminates                                   |
+| `UserPromptSubmit`    | Yes                   | Before Claude processes the user prompt              |
+| `UserPromptExpansion` | Yes                   | When a slash command expands, before reaching Claude |
+| `PreToolUse`          | **Yes (fail-closed)** | Before a tool executes                               |
+| `PostToolUse`         | No                    | After a tool succeeds                                |
+| `PostToolUseFailure`  | No                    | After a tool fails                                   |
+| `PostToolBatch`       | Yes                   | After a parallel batch of tool calls resolves        |
+| `PermissionRequest`   | Yes                   | Before the permission dialog appears                 |
+| `PermissionDenied`    | —                     | After a tool is denied by the auto-mode classifier   |
+| `Stop`                | Yes                   | When Claude finishes a turn                          |
+| `StopFailure`         | —                     | When a turn ends due to API error                    |
+| `SubagentStart`       | —                     | When a subagent is spawned                           |
+| `SubagentStop`        | Yes                   | When a subagent finishes                             |
+| `TeammateIdle`        | Yes                   | When a team member goes idle                         |
+| `TaskCreated`         | Yes                   | When a task is being created                         |
+| `TaskCompleted`       | Yes                   | When a task is marked complete                       |
+| `Notification`        | No                    | System notifications (fire-and-forget)               |
+| `MessageDisplay`      | No                    | While an assistant message displays                  |
+| `PreCompact`          | Yes                   | Before context compaction                            |
+| `PostCompact`         | —                     | After context compaction                             |
+| `FileChanged`         | —                     | When a watched file changes                          |
+| `CwdChanged`          | —                     | When the working directory changes                   |
+| `ConfigChange`        | Yes                   | When a config file changes                           |
+| `InstructionsLoaded`  | —                     | When CLAUDE.md / `.claude/rules/*.md` loads          |
+| `WorktreeCreate`      | —                     | When a git worktree is created                       |
+| `WorktreeRemove`      | —                     | When a git worktree is removed                       |
+| `Elicitation`         | —                     | When an MCP server requests user input               |
+| `ElicitationResult`   | —                     | After the user responds to an MCP elicitation        |
+
+**Matcher field** for events that support it — filters by:
+
+| Event                            | Matches against                                              |
+| -------------------------------- | ------------------------------------------------------------ |
+| Tool events                      | Tool name                                                    |
+| `SessionStart`                   | Session source: `startup`, `resume`, `clear`, `compact`      |
+| `SessionEnd`                     | End reason: `clear`, `resume`, `logout`, `other`             |
+| `Notification`                   | Notification type: `permission_prompt`, `auth_success`, etc. |
+| `SubagentStart` / `SubagentStop` | Agent type name                                              |
+| `FileChanged`                    | Literal filename                                             |
+| `Setup`                          | CLI flag: `init`, `maintenance`                              |
+
+### Handler Types
+
+| Type       | Use for                                                                                |
+| ---------- | -------------------------------------------------------------------------------------- |
+| `command`  | Shell scripts or any executable — the most common type                                 |
+| `http`     | HTTP or HTTPS POST to a configured endpoint `url`                                      |
+| `mcp_tool` | Call a tool on a connected MCP server; supports `${path}` substitution from hook input |
+| `prompt`   | Ask Claude (a sub-model) to make a yes/no decision                                     |
+| `agent`    | Spawn a subagent for complex verification (experimental)                               |
+
+**Command hook fields:**
+
+| Field           | Notes                                                                                                                       |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `command`       | Without `args` → shell form (supports pipes, `&&`, globs). With `args` → exec form (no shell; each element is one argument) |
+| `args`          | Array — use for paths with `${CLAUDE_PROJECT_DIR}` placeholders to avoid word splitting                                     |
+| `if`            | Bash pattern filter: `"Bash(rm *)"` — pre-filters before spawning the hook process                                          |
+| `async`         | `true` = fire-and-forget; agent continues without waiting                                                                   |
+| `asyncRewake`   | `true` = re-wake Claude when the async hook exits with code 2                                                               |
+| `timeout`       | Seconds (default 600 for command/http/mcp_tool, 30 for prompt)                                                              |
+| `statusMessage` | Custom spinner text shown to the user while the hook runs                                                                   |
+| `once`          | `true` = runs once per session then removes itself (skill frontmatter only)                                                 |
+
+> **Gotcha — `if` is a best-effort pre-filter, not a reliable gate.** It (and
+> `matcher`) narrow on the *tool*, not on the command's content, and a malformed
+> rule fails *open* — the hook then runs on every matched call. Observed in
+> practice: an `if: "Bash(gh pr create*)"` entry fired its reminder on *every*
+> Bash command. Do the authoritative gating **inside the script**: read the
+> tool-call JSON on stdin, match the field you care about (e.g.
+> `.tool_input.command`), and produce output only on a real match. Treat
+> `matcher`/`if` as a cheap optimization, never as correctness.
+>
+> **A soft (non-blocking) `PreToolUse` hook must `exit 0`.** Exit 2 blocks the
+> tool call (see *Exit Code 2* below), so a hook that only injects
+> `additionalContext` should print its JSON on a match, print nothing otherwise,
+> and always exit 0 — never let a "reminder" turn into an accidental block.
+
+**Path placeholders** (resolved in `command` and `args`):
+
+| Placeholder             | Value                            |
+| ----------------------- | -------------------------------- |
+| `${CLAUDE_PROJECT_DIR}` | Project root                     |
+| `${CLAUDE_PLUGIN_ROOT}` | Plugin installation directory    |
+| `${CLAUDE_PLUGIN_DATA}` | Plugin persistent data directory |
+
+**`CLAUDE_ENV_FILE`** — Available in `SessionStart`, `Setup`, `CwdChanged`, and `FileChanged` hooks. Write `export VAR=value` lines to this file to persist variables into subsequent Bash commands for the rest of the session.
+
+```bash
+#!/bin/bash
+# SessionStart hook — inject branch info
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+  echo "export CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> "$CLAUDE_ENV_FILE"
+fi
+```
+
+### JSON Input
+
+All events receive this JSON on stdin:
+
+```json
+{
+  "session_id": "abc123",
+  "transcript_path": "/path/to/transcript.jsonl",
+  "cwd": "/project",
+  "permission_mode": "default",
+  "hook_event_name": "PreToolUse",
+  "effort": { "level": "high" }
+}
+```
+
+Tool events add `tool_name` and `tool_input`. Subagent events add `agent_id` and `agent_type`.
+
+### JSON Output — Universal Fields
+
+| Field              | Default | Effect                                                                                    |
+| ------------------ | ------- | ----------------------------------------------------------------------------------------- |
+| `continue`         | `true`  | `false` stops Claude entirely; shows `stopReason` to the user                             |
+| `suppressOutput`   | `false` | Hide hook stdout from the session transcript                                              |
+| `systemMessage`    | —       | Warning shown to the user (not the model)                                                 |
+| `terminalSequence` | —       | Terminal escape sequence — use instead of writing to `/dev/tty` (OSC 0/1/2/9/99/777, BEL) |
+
+### JSON Output — Event-Specific
+
+**`PreToolUse`:**
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Writes to /etc are not allowed",
+    "additionalContext": "Extra info injected for Claude",
+    "updatedInput": { "command": "modified command" }
+  }
+}
+```
+
+`permissionDecision` values: `allow`, `deny`, `ask`, `defer`. When multiple hooks fire: `deny` > `defer` > `ask` > `allow`.
+
+**`PostToolUse`:**
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "This file is generated — edit src/schema.ts instead.",
+    "updatedToolOutput": "Replacement output that Claude sees instead of the real result"
+  }
+}
+```
+
+**`SessionStart`:**
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "Branch: main\nLast CI: green",
+    "initialUserMessage": "First message to send automatically",
+    "sessionTitle": "Auto-generated session name",
+    "watchPaths": ["/path/to/watch"],
+    "reloadSkills": true
+  }
+}
+```
+
+**`Stop` / `SubagentStop` / `PostToolBatch` / `UserPromptSubmit`:**
+
+```json
+{
+  "decision": "block",
+  "reason": "Explanation injected as the next user turn when blocking"
+}
+```
+
+### Exit Code 2 — Blocking Effects
+
+| Events                                                                         | Effect                                                  |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| `PreToolUse`, `PermissionRequest`, `UserPromptSubmit`, `Stop`, `PostToolBatch` | Blocks the action                                       |
+| `SubagentStop`, `TaskCreated`, `TaskCompleted`, `ConfigChange`, `PreCompact`   | Blocks the action                                       |
+| `PostToolUse`, `PostToolUseFailure`                                            | Shows stderr to Claude (tool already ran; cannot block) |
+| `Notification`, `SessionStart`, `SessionEnd`, etc.                             | Shows stderr to the user                                |
+
+### Policy Controls
+
+```json
+{ "disableAllHooks": true }
+```
+
+In a single `hooks/*.json` file → skips that file only.
+In `settings.json` → disables all hooks for that project (policy hooks are unaffected).
+
+`allowManagedHooksOnly` in managed policy → blocks all user/project/plugin hooks; only force-enabled plugin hooks run.
+
+---
+
+## B. Agent SDK — Callback Function Hooks
+
+SDK hooks are **async callback functions** registered in code. No shell is spawned; the callback runs in the same process. Both Python and TypeScript SDKs support the same event model with minor API differences.
+
+### Configuration
+
+```typescript
+// TypeScript
+for await (const message of query({
+  prompt: "...",
+  options: {
+    hooks: {
+      PreToolUse: [{ matcher: "Write|Edit", hooks: [myCallback] }]
+    }
+  }
+})) { ... }
+```
+
+```python
+# Python
+options = ClaudeAgentOptions(
+    hooks={"PreToolUse": [HookMatcher(matcher="Write|Edit", hooks=[my_callback])]}
+)
+async with ClaudeSDKClient(options=options) as client:
+    await client.query("...")
+```
+
+To also load shell command hooks from settings files, pass the appropriate `settingSources` / `setting_sources`:
+
+```python
+options = ClaudeAgentOptions(setting_sources=["project"])  # loads .claude/settings.json
+```
+
+### HookMatcher Fields
+
+| Field     | Type       | Default  | Notes                              |
+| --------- | ---------- | -------- | ---------------------------------- |
+| `matcher` | string     | —        | Same pattern rules as CLI matchers |
+| `hooks`   | callback[] | required | Array of async functions           |
+| `timeout` | number     | 60       | Seconds                            |
+
+### Callback Signature
+
+```typescript
+// TypeScript
+const myHook: HookCallback = async (input, toolUseID, { signal }) => {
+  // input — typed per event: PreToolUseHookInput, PostToolUseHookInput, etc.
+  // toolUseID — correlates PreToolUse ↔ PostToolUse for the same tool call
+  // signal — AbortSignal; pass to fetch() so HTTP requests cancel on timeout
+  return {};  // empty = allow, no modification
+};
+```
+
+```python
+# Python
+async def my_hook(input_data, tool_use_id, context):
+    # input_data: dict; input_data["hook_event_name"] tells you the event type
+    # tool_use_id: correlates Pre ↔ Post for the same call
+    return {}
+```
+
+All hook inputs share `session_id`, `cwd`, `hook_event_name`. `agent_id` and `agent_type` are set when the hook fires inside a subagent.
+
+### Available Events
+
+| Event                | Python | TypeScript | Notes                                                          |
+| -------------------- | ------ | ---------- | -------------------------------------------------------------- |
+| `PreToolUse`         | Yes    | Yes        | Fail-closed; supports deny/allow/ask/defer                     |
+| `PostToolUse`        | Yes    | Yes        | Can inject `additionalContext` or replace output               |
+| `PostToolUseFailure` | Yes    | Yes        | Tool already failed                                            |
+| `PostToolBatch`      | No     | Yes        | Fires once per parallel batch before the next model call       |
+| `UserPromptSubmit`   | Yes    | Yes        | Can block or add context                                       |
+| `MessageDisplay`     | No     | Yes        | Redact/reformat displayed text without changing the transcript |
+| `Stop`               | Yes    | Yes        | Can block to force continuation                                |
+| `SubagentStart`      | Yes    | Yes        |                                                                |
+| `SubagentStop`       | Yes    | Yes        |                                                                |
+| `PreCompact`         | Yes    | Yes        |                                                                |
+| `PermissionRequest`  | Yes    | Yes        |                                                                |
+| `Notification`       | Yes    | Yes        | Use `async: true` — fire-and-forget                            |
+| `SessionStart`       | **No** | Yes        | Python: use shell hooks in `.claude/settings.json`             |
+| `SessionEnd`         | **No** | Yes        | Python: same workaround                                        |
+| `Setup`              | No     | Yes        |                                                                |
+| `TeammateIdle`       | No     | Yes        |                                                                |
+| `TaskCompleted`      | No     | Yes        |                                                                |
+| `ConfigChange`       | No     | Yes        |                                                                |
+| `WorktreeCreate`     | No     | Yes        |                                                                |
+| `WorktreeRemove`     | No     | Yes        |                                                                |
+
+### Output Format
+
+```typescript
+return {
+  // Top-level — all events
+  systemMessage: "Warning shown to user",
+  continue: true,          // false = stop agent entirely
+
+  // Event-specific
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",       // required — identifies the event
+    permissionDecision: "deny",
+    permissionDecisionReason: "Not allowed",
+    updatedInput: { file_path: "/sandbox/foo.txt" },  // modified args
+    additionalContext: "Info for Claude"
+  }
+};
+```
+
+Return `{}` to allow the operation without changes. `hookSpecificOutput` must always include `hookEventName`.
+
+### Async Side Effects
+
+```typescript
+// TypeScript
+return { async: true, asyncTimeout: 30000 };
+```
+
+```python
+# Python — avoid the reserved keyword
+return {"async_": True, "asyncTimeout": 30000}
+```
+
+Async hooks cannot block, modify, or inject context — the agent has already continued. Use only for logging, telemetry, and notifications.
+
+### Multiple Hooks — Parallel Execution & Priority
+
+When multiple hooks match an event, they run **in parallel**. For permission decisions, the most restrictive wins: `deny` > `defer` > `ask` > `allow`. Write each hook to act independently — do not rely on another hook having run first.
+
+### Python vs TypeScript Differences
+
+|                                         | Python                                                 | TypeScript      |
+| --------------------------------------- | ------------------------------------------------------ | --------------- |
+| `async` return field                    | `async_` (reserved keyword)                            | `async`         |
+| `continue` return field                 | `continue_`                                            | `continue`      |
+| `SessionStart` / `SessionEnd`           | Not available as SDK callbacks                         | Available       |
+| `PostToolBatch`, `MessageDisplay`, etc. | Not available                                          | Available       |
+| `agent_id` / `agent_type`               | `PreToolUse`, `PostToolUse`, `PostToolUseFailure` only | All hook inputs |

--- a/.claude/skills/ref-md-agents-hooks/references/hooks-copilot.md
+++ b/.claude/skills/ref-md-agents-hooks/references/hooks-copilot.md
@@ -1,0 +1,213 @@
+# Hooks — GitHub Copilot CLI
+
+## Events
+
+| Event                 | Blocks                | Fires when                 | CLI | Cloud Agent        |
+| --------------------- | --------------------- | -------------------------- | --- | ------------------ |
+| `sessionStart`        | No                    | Session begins or resumes  | Yes | Yes                |
+| `sessionEnd`          | No                    | Session terminates         | Yes | Yes                |
+| `userPromptSubmitted` | —                     | User submits a prompt      | Yes | Yes (at most once) |
+| `preToolUse`          | **Yes (fail-closed)** | Before a tool executes     | Yes | Yes                |
+| `postToolUse`         | No                    | After a tool succeeds      | Yes | Yes                |
+| `postToolUseFailure`  | No                    | After a tool fails         | Yes | Yes                |
+| `agentStop`           | Yes                   | Main agent finishes a turn | Yes | Yes                |
+| `subagentStart`       | —                     | Before a subagent spawns   | Yes | Yes                |
+| `subagentStop`        | Yes                   | When a subagent completes  | Yes | Yes                |
+| `errorOccurred`       | —                     | An error occurs            | Yes | Yes                |
+| `preCompact`          | —                     | Before context compaction  | Yes | Auto-trigger only  |
+| `permissionRequest`   | Yes                   | Before permission dialog   | Yes | **No**             |
+| `notification`        | No                    | System notifications       | Yes | **No**             |
+
+**Cloud agent restrictions:** Linux-only sandbox; only the `bash` field is honored (`powershell` ignored, `command` as fallback); no `permissionRequest` or `notification` events; network is restricted to GitHub/Copilot hosts; filesystem is ephemeral. Use `preToolUse` instead of `permissionRequest` in cloud environments.
+
+## Naming Conventions
+
+Copilot supports two JSON formats. Pick one consistently — do not mix within a session:
+
+| Convention                 | Event name style         | Field style                           | When to use                               |
+| -------------------------- | ------------------------ | ------------------------------------- | ----------------------------------------- |
+| **Standard (CLI default)** | camelCase: `preToolUse`  | camelCase: `toolName`, `toolArgs`     | New hooks, CLI-only                       |
+| **VS Code compatible**     | PascalCase: `PreToolUse` | snake_case: `tool_name`, `tool_input` | Hooks shared with Claude Code / Agent SDK |
+
+In VS Code compatible format, Claude tool names map to Copilot tool names: `bash/powershell` → `Bash`, `view` → `Read`, `create` → `Write`, `edit` → `Edit`, `glob` → `Glob`, `grep/rg` → `Grep`, `web_fetch` → `WebFetch`, `task` → `Agent`.
+
+## Configuration Files & Load Order
+
+Hooks from all sources for the same event run together in this order:
+
+1. **Policy** — `/etc/github-copilot/policy.d/*.json` (macOS/Linux) or `C:\ProgramData\GitHub\Copilot\policy.d\*.json` (Windows) or Windows Registry `HKLM\Software\Policies\GitHub\Copilot` — loaded first; cannot be disabled
+2. **User** — `~/.copilot/hooks/*.json` (or `$COPILOT_HOME/hooks/`)
+3. **Repository** — `.github/hooks/*.json` — the only location supported in cloud agent
+4. **Inline (repository)** — `hooks` key in `.github/copilot/settings.json` or `.github/copilot/settings.local.json`
+5. **Inline (user)** — `hooks` key in `~/.copilot/settings.json`
+6. **Plugin** — `hooks.json` inside plugin installation directory
+
+Hook configuration is loaded when the CLI starts; restart required to pick up changes.
+
+## Handler Types
+
+| Type      | Notes                                                                                                           |
+| --------- | --------------------------------------------------------------------------------------------------------------- |
+| `command` | Shell command. Requires both `bash` and `powershell` fields for cross-platform support; `command` as a fallback |
+| `http`    | HTTPS POST to an endpoint. HTTP only allowed for localhost with `COPILOT_HOOK_ALLOW_LOCALHOST=1`                |
+| `prompt`  | Text prompt evaluated by the LLM                                                                                |
+
+## Configuration Schema
+
+```json
+{
+  "version": 1,
+  "disableAllHooks": false,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "/path/to/check.sh",
+        "powershell": "powershell -File /path/to/check.ps1",
+        "command": "/path/to/check.sh",
+        "cwd": "/optional/working/dir",
+        "env": { "MY_VAR": "value" },
+        "timeoutSec": 30,
+        "matcher": "bash|edit"
+      }
+    ]
+  }
+}
+```
+
+HTTP hook:
+
+```json
+{
+  "type": "http",
+  "url": "https://hooks.example.com/copilot",
+  "headers": { "X-Source": "copilot-cli" },
+  "allowedEnvVars": ["GITHUB_TOKEN"],
+  "timeoutSec": 30
+}
+```
+
+`allowedEnvVars` — lists env vars that may be interpolated into the URL or headers. HTTP hooks are **fail-open** for `preToolUse` (unlike command hooks, which are fail-closed).
+
+## Input Payloads
+
+All events include `sessionId`, `timestamp` (Unix ms), `cwd`.
+
+**`preToolUse` (standard camelCase):**
+
+```json
+{
+  "sessionId": "abc123",
+  "timestamp": 1704614400000,
+  "cwd": "/project",
+  "toolName": "bash",
+  "toolArgs": { "command": "npm test" }
+}
+```
+
+**`agentStop`:**
+
+```json
+{
+  "sessionId": "abc123",
+  "timestamp": 1704614400000,
+  "cwd": "/project",
+  "transcriptPath": "/path/to/transcript",
+  "stopReason": "end_turn"
+}
+```
+
+**`notification`:**
+
+```json
+{
+  "sessionId": "abc123",
+  "timestamp": 1704614400000,
+  "cwd": "/project",
+  "hook_event_name": "Notification",
+  "message": "Human-readable status",
+  "title": "Optional title",
+  "notification_type": "permission_prompt"
+}
+```
+
+## Output Payloads
+
+**`preToolUse`:**
+
+```json
+{
+  "permissionDecision": "allow|deny|ask",
+  "permissionDecisionReason": "Required when decision is deny",
+  "modifiedArgs": { "command": "modified command" }
+}
+```
+
+**`agentStop` / `subagentStop`:**
+
+```json
+{
+  "decision": "block|allow",
+  "reason": "Prompt injected as next user turn when blocking"
+}
+```
+
+**`postToolUse`:**
+
+```json
+{
+  "modifiedResult": { "resultType": "success", "textResultForLlm": "Replacement output" },
+  "additionalContext": "Extra info (max 10 KB combined across all hooks)"
+}
+```
+
+**`permissionRequest`:**
+
+```json
+{
+  "behavior": "allow|deny",
+  "message": "Reason fed to LLM when denying",
+  "interrupt": false
+}
+```
+
+`interrupt: true` with `deny` stops the agent entirely instead of just blocking the single tool call.
+
+## Exit Codes
+
+| Code           | Behavior                                                                                                            |
+| -------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `0`            | Parse stdout as JSON                                                                                                |
+| `2`            | Warning surfaced to user; `permissionRequest` treats it as deny; `postToolUseFailure` uses it as additional context |
+| Other non-zero | Logged as failure; agent continues — **except `preToolUse` is fail-closed**                                         |
+| Timeout        | Hook killed; `preToolUse` timeout = deny                                                                            |
+
+## Progress Messages
+
+Command hooks can write progress updates to stdout while running. Progress lines are stripped before final JSON parsing.
+
+```bash
+echo '{"type": "progress", "message": "Checking security policy…"}'
+echo '{"type": "progress", "message": "Routing request…", "temporary": true}'
+```
+
+`temporary: true` replaces the previous transient line in the UI (spinner effect). Use for intermediate status; use non-temporary for permanent log lines.
+
+## `disableAllHooks`
+
+```json
+{ "version": 1, "disableAllHooks": true }
+```
+
+In a single `hooks/*.json` file → skips that file only.
+In `settings.json` → disables all hooks for that repository (policy hooks are unaffected).
+
+## Tool Names for Matching
+
+Built-in tools available for `preToolUse` / `postToolUse` matchers:
+
+`ask_user`, `bash`, `create`, `edit`, `glob`, `grep`, `powershell`, `rg`, `task`, `update_todo`, `view`, `web_fetch`, `web_search`
+
+## Cloud Agent Environment Variables
+
+`GITHUB_COPILOT_API_TOKEN`, `GITHUB_COPILOT_GIT_TOKEN`, `COPILOT_AGENT_PROMPT`, `HOME=/root`. Note: `GITHUB_TOKEN` is **not** set in the cloud agent sandbox.

--- a/.claude/skills/ref-md-agents-hooks/references/hooks-gemini.md
+++ b/.claude/skills/ref-md-agents-hooks/references/hooks-gemini.md
@@ -1,0 +1,160 @@
+# Hooks — Gemini CLI
+
+## Events
+
+Gemini CLI exposes 10 lifecycle events. Several are unique to Gemini — they fire at **model-call granularity** rather than just tool granularity, giving finer-grained control than the other platforms:
+
+| Event                 | Blocks                | Fires when                                            | Unique to Gemini |
+| --------------------- | --------------------- | ----------------------------------------------------- | ---------------- |
+| `SessionStart`        | No                    | Session begins                                        |                  |
+| `SessionEnd`          | No                    | Session ends                                          |                  |
+| `BeforeAgent`         | Yes                   | After prompt submission, before the agent loop starts | ✓                |
+| `AfterAgent`          | Yes                   | After the agent loop completes a turn                 | ✓                |
+| `BeforeModel`         | Yes                   | Before every LLM API request                          | ✓                |
+| `AfterModel`          | Yes                   | After every LLM response                              | ✓                |
+| `BeforeToolSelection` | Yes                   | Before the model selects which tool to call           | ✓                |
+| `BeforeTool`          | **Yes (exit 2 only)** | Before a tool executes                                |                  |
+| `AfterTool`           | Yes                   | After a tool executes                                 |                  |
+| `PreCompress`         | No                    | Before context compression                            |                  |
+
+**Prefer `AfterAgent` over `AfterModel` for end-of-turn validation.** `AfterModel` fires on every model call including streaming chunks; `AfterAgent` fires once per completed turn. Use `AfterModel` only when you need real-time per-response processing.
+
+**`BeforeToolSelection`** is a lighter intervention than `BeforeTool` — it lets you filter the available tool list before the model even picks one, rather than blocking after the model has already committed to a tool call.
+
+## Configuration
+
+Hooks are defined in `settings.json` under a `hooks` key. Configuration layers (highest to lowest precedence):
+
+1. Project: `.gemini/settings.json`
+2. User: `~/.gemini/settings.json`
+3. System: `/etc/gemini-cli/settings.json`
+4. Extensions
+
+```json
+{
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "write_file|replace",
+        "hooks": [
+          {
+            "name": "security-check",
+            "type": "command",
+            "command": "${GEMINI_PROJECT_DIR}/.gemini/hooks/security.sh",
+            "timeout": 5000,
+            "description": "Validates writes against security policy"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Only `"command"` type is currently supported.
+
+## Hook Fields
+
+| Field         | Required | Notes                                                                |
+| ------------- | -------- | -------------------------------------------------------------------- |
+| `type`        | Yes      | `"command"` only                                                     |
+| `command`     | Yes      | Shell command or script path                                         |
+| `name`        | No       | Friendly identifier shown in logs and the `/hooks` panel             |
+| `timeout`     | No       | Milliseconds (default 60000)                                         |
+| `description` | No       | Purpose explanation shown in the UI                                  |
+| `matcher`     | No       | Regex for tool events; exact string for lifecycle events (see below) |
+
+Make scripts executable before use: `chmod +x .gemini/hooks/*.sh`
+
+## Matchers
+
+Matcher behavior differs by event type — a single field but two semantics:
+
+| Event type                                                          | Matcher evaluated as   | Example                               |
+| ------------------------------------------------------------------- | ---------------------- | ------------------------------------- |
+| Tool events (`BeforeTool`, `AfterTool`)                             | **Regular expression** | `"write_.*"`, `"write_file\|replace"` |
+| Lifecycle events (`BeforeAgent`, `AfterAgent`, `BeforeModel`, etc.) | **Exact string**       | `"startup"`                           |
+| `*` or `""` or omitted                                              | Wildcard — matches all |                                       |
+
+## Input to Hooks
+
+Hooks receive JSON on **stdin**. All events include `session_id`. Tool events add `tool_name` and `tool_args`:
+
+```json
+{
+  "session_id": "abc123",
+  "tool_name": "write_file",
+  "tool_args": { "path": "src/foo.ts", "content": "..." }
+}
+```
+
+**Environment variables set for every hook process:**
+
+| Variable             | Value                                         |
+| -------------------- | --------------------------------------------- |
+| `GEMINI_PROJECT_DIR` | Project root                                  |
+| `GEMINI_PLANS_DIR`   | Plans directory                               |
+| `GEMINI_SESSION_ID`  | Current session ID                            |
+| `GEMINI_CWD`         | Current working directory                     |
+| `CLAUDE_PROJECT_DIR` | Alias of `GEMINI_PROJECT_DIR` (compatibility) |
+
+## Exit Codes & Output
+
+| Exit code | Behavior                                                               |
+| --------- | ---------------------------------------------------------------------- |
+| `0`       | Parse stdout as JSON                                                   |
+| `2`       | Critical block; stderr becomes the rejection message shown to the user |
+| Other     | Non-fatal warning; execution continues with original parameters        |
+
+**stdout must contain only valid JSON.** Malformed output causes the CLI to default to "Allow" and surface the error as a system message.
+
+**Block a tool call:**
+
+```json
+{ "decision": "deny", "reason": "Path is restricted to /src" }
+```
+
+**Stop the agent loop entirely:**
+
+```json
+{ "continue": false }
+```
+
+**Suppress metadata from session logs** (user-facing messages still display):
+
+```json
+{ "suppressOutput": true }
+```
+
+## Project Hook Fingerprinting
+
+Gemini generates a unique identity for each project hook based on its `name` and `command`. When a hook runs for the first time, or when its `command` changes, the CLI warns the user before executing. This prevents silent substitution attacks — a PR that modifies a hook script will trigger the warning on the next run.
+
+Project hooks (`.gemini/` directory) are untrusted by default. Review hook scripts from third-party sources before enabling.
+
+## `environmentVariableRedaction`
+
+Off by default. Prevents env var values from appearing in logs or hook output. Enable explicitly:
+
+```json
+{
+  "security": {
+    "environmentVariableRedaction": {
+      "enabled": true,
+      "allowed": ["MY_REQUIRED_TOOL_KEY"]
+    }
+  }
+}
+```
+
+## Gemini-Specific Best Practices
+
+| What                                                         | Why                                                                                               |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Use `AfterAgent` not `AfterModel` for end-of-turn checks     | `AfterModel` fires on every chunk; `AfterAgent` fires once per turn                               |
+| Use `BeforeToolSelection` to filter available tools          | Lighter than blocking at `BeforeTool` — prevents the model from committing to a tool you'd reject |
+| Cache per-session lookups in `.gemini/hook-cache.json`       | Avoid repeating expensive policy or auth lookups on every tool call                               |
+| Set tight `timeout` for fast validators (`5000` ms)          | Default is 60 s — a validator that takes 60 s visibly delays the agent                            |
+| Use precise matchers on tool events                          | Tool matchers are regex; `"write_file\|replace"` instead of `".*"`                                |
+| Enable `environmentVariableRedaction` for any hook that logs | Prevents accidental secret leakage into hook output or debug files                                |
+| Version-control hook scripts alongside `settings.json`       | Keeps the fingerprint stable; use `.gitignore` only for cache files and logs                      |

--- a/.claude/skills/ref-md-agents-hooks/references/hooks-shared.md
+++ b/.claude/skills/ref-md-agents-hooks/references/hooks-shared.md
@@ -1,0 +1,102 @@
+# Hooks — Shared Concepts
+
+Concepts that apply across Claude Code, Copilot CLI, and Gemini CLI. For platform-specific event lists, configuration format, and handler types, see the sibling reference files.
+
+## Execution Model
+
+Hooks run **synchronously** in the agent loop by default — the agent pauses until all matching hooks for an event complete before continuing. This makes them reliable for blocking decisions and context injection, but means slow hooks directly delay the agent.
+
+Use **async / fire-and-forget mode** (when the platform supports it) for pure side effects — logging, telemetry, webhooks — where you do not need to influence the agent's behavior. In async mode the agent continues immediately without waiting.
+
+## Universal Event Categories
+
+Every platform organizes events into the same conceptual buckets:
+
+| Category         | What it covers                                                          | Block capable                                    |
+| ---------------- | ----------------------------------------------------------------------- | ------------------------------------------------ |
+| **Session**      | Session start and end — initialization, cleanup, inject initial context | Typically no (advisory)                          |
+| **Tool**         | Before and after each tool call — the primary interception point        | Yes — fail-closed varies by platform (see below) |
+| **Agent turn**   | When the agent loop finishes a turn, or is about to start one           | Yes                                              |
+| **Subagent**     | When a subagent is spawned or finishes                                  | Depends on platform                              |
+| **Compaction**   | Before context is compressed                                            | Claude only (`PreCompact`); advisory elsewhere   |
+| **Notification** | System messages from the agent — relay to Slack, PagerDuty, etc.        | No (fire-and-forget)                             |
+
+See the platform-specific reference for the full event list and which events can block vs. are advisory.
+
+## Matchers
+
+All platforms support filtering hooks by **tool name** or **event subtype** using a matcher. Matchers keep hooks focused and avoid spawning processes for irrelevant events.
+
+| Matcher value                  | Behavior                                 |
+| ------------------------------ | ---------------------------------------- |
+| Omitted / `*` / `""`           | Fires for every occurrence of the event  |
+| `Write`, `Bash`                | Exact tool name match                    |
+| `Write\|Edit` or `Write, Edit` | Exact match for either name              |
+| Contains any other character   | Treated as a regex: `^mcp__`, `write_.*` |
+
+**Matchers filter by tool name only** — not by file path or command arguments. To filter by path, check `tool_input.file_path` inside the hook body.
+
+Use precise matchers whenever possible. A wildcard matcher spawns the hook process for every tool call; a `Write|Edit` matcher spawns it only for file-write tools.
+
+## Exit Codes (shell hooks)
+
+| Code           | Meaning                                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------------------- |
+| `0`            | Success — parse stdout as JSON; empty stdout means no decision                                                |
+| `2`            | Blocking error — ignore stdout; use stderr as the error message; block the action where the event supports it |
+| Other non-zero | Non-blocking error — logged, execution continues                                                              |
+
+**`PreToolUse` hooks are fail-closed on Claude Code and Copilot CLI:** a crash, non-zero exit, or timeout denies the tool call automatically. **Gemini CLI's `BeforeTool` is fail-closed only on exit 2** — any other non-zero exit or malformed stdout JSON is a non-fatal warning and the tool executes with its original parameters (fail-open).
+
+## The Golden Rule: stdout = JSON, stderr = logs
+
+All platforms require that **stdout contains only valid JSON** when you want structured output. Any plain text in stdout causes JSON parsing to fail and the hook's decision to be ignored.
+
+Write all debugging, tracing, and logging to **stderr**:
+
+```bash
+echo "debug: checking path: $path" >&2            # ✓ stderr — never parsed
+echo '{"permissionDecision":"deny","permissionDecisionReason":"Path blocked"}'  # ✓ stdout — JSON only
+```
+
+Validate your JSON before deploying:
+
+```bash
+echo "$output" | jq empty 2>/dev/null || { echo "Invalid JSON" >&2; exit 1; }
+```
+
+## Common Output Fields
+
+All platforms support a subset of these top-level fields in JSON output:
+
+| Field                             | What it does                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------- |
+| `continue` / `continue_` (Python) | `false` stops the agent entirely after this hook fires                          |
+| `systemMessage`                   | Warning message shown to the user (not injected into model context)             |
+| `additionalContext`               | Extra text injected into the conversation for the **model** to see (max ~10 KB) |
+
+Event-specific decisions (allow/deny/block, modified inputs, replacement outputs) go inside a nested `hookSpecificOutput` object on Claude and Copilot, or as top-level `decision` fields on Gemini. See the platform references for exact schemas.
+
+**When multiple hooks fire for the same event: deny wins.** A single deny blocks the operation regardless of what other hooks return.
+
+## Writing Effective Hooks
+
+| What                                       | Why                                                            | How                                                                  |
+| ------------------------------------------ | -------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Keep hooks fast                            | Hooks block the agent loop — slow hooks = slow agent           | Exit early; cache expensive lookups; use async mode for side effects |
+| Use precise matchers                       | Avoid spawning processes for irrelevant events                 | `Write\|Edit` instead of no matcher for file-write hooks             |
+| Write one hook per concern                 | Focused hooks are easier to test and reason about              | Block in one hook, log in another                                    |
+| Validate JSON input before acting          | LLM-supplied args may be malformed or adversarial              | `jq empty` before parsing tool arguments                             |
+| Test hooks in isolation                    | Catch output format bugs before deployment                     | `echo '{"tool_name":"Bash",...}' \| bash hook.sh`                    |
+| Provide clear denial reasons               | The model uses the reason to avoid retrying the blocked action | `"permissionDecisionReason": "Writes to /etc are not allowed"`       |
+| Write logs to stderr or a file, not stdout | Text in stdout breaks JSON parsing                             | `echo "debug: ..." >&2` or `>> .claude/hooks/debug.log`              |
+| Handle errors internally                   | Uncaught exceptions can interrupt the agent                    | Wrap HTTP calls and side effects in try/catch                        |
+| Use `jq` for JSON parsing                  | `grep`/`sed` on JSON is fragile                                | `tool=$(echo "$input" \| jq -r '.tool_name')`                        |
+
+## Security
+
+- Hooks run with **your user's privileges** — they inherit your full environment, including secrets set in `.env` files that your shell has sourced.
+- **Never trust LLM-supplied arguments without validation.** Prompt injection can cause the model to call tools with attacker-controlled values. Always validate `tool_input` fields before acting on them.
+- **Do not log or echo secret values** from env vars or hook input — hook stdout and stderr may appear in session transcripts.
+- Set strict `timeout` values on hooks that call external services to prevent denial-of-service delays against the agent loop.
+- Project-level hooks in public repositories are untrusted by default on some platforms (Gemini fingerprints them; Claude Code and Copilot have policy controls). Review hook scripts from third-party sources before enabling.

--- a/.claude/skills/ref-md-agents-local-tasks/SKILL.md
+++ b/.claude/skills/ref-md-agents-local-tasks/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: ref-md-agents-local-tasks
+description: >-
+  Maintain repo-local task tracking files under `.agents/tasks/` (or a legacy
+  `.claude/tasks/`). Use when: planning a
+  multi-step task, breaking work into subtasks, tracking execution status, recording
+  blockers, or maintaining next steps across chat sessions. Covers the task-root
+  new/open/closed lifecycle, file structure, README anatomy, proactive status updates, and why a filed solution is a hint the handling agent validates rather than a prescription. Works across all agents
+  (Copilot, Claude Code) as a persistent, git-ignored task journal.
+metadata:
+  author: mindoktor
+  version: "2.6"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "agents"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+  shareable-skills.suggests: "ref-md-dev-coding-patterns, ref-md-agents-skills-authoring"
+---
+
+# Local Task Tracking
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+Structured, git-ignored task journals under `.agents/tasks/` that persist across chat sessions and work with any AI agent.
+
+**Task root:** this skill writes `.agents/tasks/` throughout — the provider-neutral agent dir and the standard for new setups. A repo not yet migrated may still keep its journal under `.claude/tasks/`; check which root exists (`ls -d .agents/tasks .claude/tasks`) and substitute it consistently. Never create a second root next to an existing one.
+
+## Why This Exists
+
+AI agents have built-in tools for in-session tracking (Copilot's `manage_todo_list`, `/memories/session/`) and cross-session learnings (Claude Code's auto memory at `~/.claude/projects/<project>/memory/`), but none provide **structured execution plans** that persist across sessions:
+
+| Built-in feature             | Persists?     | Structured plans?              | Cross-agent?     |
+| ---------------------------- | ------------- | ------------------------------ | ---------------- |
+| Copilot `manage_todo_list`   | No (per chat) | Steps only, no phases          | Copilot only     |
+| Copilot `/memories/session/` | No (per chat) | Free-form                      | Copilot only     |
+| Copilot `/memories/repo/`    | Yes           | Free-form                      | Copilot only     |
+| Claude Code auto memory      | Yes           | Free-form learnings            | Claude Code only |
+| **`.agents/tasks/`**         | **Yes**       | **Objective → Status → TODOs** | **Any agent**    |
+
+This skill fills the gap: a persistent, structured task journal with objectives, phased checklists, status tracking, and blockers — readable and writable by any agent.
+
+It also works as a **user-to-agent inbox**: the user can edit the file while the agent is busy (adding new tasks, reprioritizing, leaving notes), and the agent picks up the changes next time it checks the tracker.
+
+**This skill is not for Jira work item authoring** — that is handled by skills registered in the repo's instruction index (`AGENTS.md`, or a legacy `.github/copilot-instructions.md`; see the Skills table).
+
+## Your Continuous Responsibility
+Keep the tracking files current. If we complete a step, hit a blocker, or change direction, immediately reflect that in the corresponding `README.md`. Treat the file as a living execution record.
+
+## File Structure and Naming
+One task = one folder, filed under a **lifecycle** subfolder.
+- **Location:** `.agents/tasks/<lifecycle>/<task-name>/`, where `<lifecycle>` is `new`, `open`, or `closed` (see below).
+- **Naming:** PR-style kebab-case (e.g., `.agents/tasks/new/add-hotkey-configuration/`)
+- **Entry point:** Every task folder must contain a `README.md`
+- **`TODO.md` stays at the root** (`.agents/tasks/TODO.md`) — it is the quick-task inbox, not a lifecycle bucket.
+
+## Task Lifecycle: `new` / `open` / `closed`
+
+Tasks are bucketed into three sibling folders so `ls .agents/tasks/` gives an at-a-glance overview. The folder is the **coarse** status; each README's `## Current Status` carries the detail.
+
+| Folder    | Meaning                            | Enters when…                                                                                              |
+| --------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `new/`    | Created but **work not started**   | Captured/refined but no work has begun — includes a task deferred, or blocked, *before* starting          |
+| `open/`   | **Work has started** (in progress) | The first real work lands — includes a task blocked *after* starting, or partly done with a deferred tail |
+| `closed/` | **Done or cancelled**              | The objective is met, or the task is abandoned / won't-pursue                                             |
+
+**The boundary rule is simply "has work started?"** — not whether the task is deferred or blocked. A deferred/blocked task that has *not* started stays in `new`; one that started and then got blocked lives in `open`. Move a task `new → open` when work begins, and `open → closed` when it is done or cancelled.
+
+**When moving a task between folders, fix its relative cross-links.** The task's depth changes, so links to `../../skills/…` or to sibling tasks (`../<other-task>/`) shift by one `../` and may need to route through the new bucket (e.g. `../../open/<task>/`). Prefer referencing skills **by name** over relative paths to avoid this (see `ref-md-agents-skills-authoring`). Keep a short `closed/README.md` index of archived tasks and their disposition so the archive stays scannable.
+
+## The `README.md` Anatomy
+- **# [Task Name]:** The main title.
+- **## Objective:** What we are building and why.
+- **## Current Status:** Most recent findings, blockers, or completed work. **(Update this dynamically as context changes.)**
+- **## Next Steps (Proposed TODOs):** Remaining work.
+  - Group into logical phases using `###` subheadings.
+  - Use GitHub-flavored checkboxes:
+    `- [ ] Pending step`
+    `- [x] Completed step`
+
+## Rules for the AI
+1. **Monitor Context:** Keep the current task's `README.md` in mind as we progress.
+2. **Update Proactively:** Check off completed items, add discovered subtasks, adjust Current Status.
+3. **Communicate:** Summarize what changed so the user can confirm the tracker still matches reality.
+4. **Write for a fresh agent:** Every task must be understandable by an agent starting a new session with no conversation history. Include enough **context** — what is wrong or needed, where, why it matters, and what patterns to follow. A task that says "fix the file" is useless; a task that says "in `path/to/File.tsx` (`~/dev/mindoktor`) `Box`+`display:flex` should likely become `Stack` per components.md § Stack over Box" is actionable. Actionable means *enough context to start*, not *a mandated solution*.
+5. **A filed solution is a hint, never a prescription.** The agent that later handles the task owns the final call — it has context you (the filing agent) may lack and may find a better fix. So always give the context; when you include a solution, frame it as *one possible way, to be validated on the way in* — "one way to do this is X, but confirm it still holds and choose what works best" — not as a settled verdict. This holds even for a fix that looks clear and mechanical: the handling agent should still confirm it before applying, because the codebase may have moved. Never manufacture a solution just to fill `## Next Steps`; when you genuinely don't know the fix, state the problem and any workaround already applied and leave the solution open. This matters most on a *problem hand-off* (e.g. an upstream fix filed from a consumer repo), where prescribing would presume on context you do not have.
+6. **Keep the bucket honest:** move a task `new → open` when work starts and `→ closed` when it is done or cancelled, and fix its relative cross-links on the move. The folder should never contradict the README's `## Current Status`.
+
+## Playground / Scratch Space
+
+Use `.agents/playground/` for temporary files an agent needs during a task — draft scripts, test fixtures, intermediate outputs, scratch notes. This folder is git-ignored and safe for throwaway content. Do not store task plans here; those belong in `.agents/tasks/`.
+
+## Quick-Task Inbox: `TODO.md`
+
+For small, standalone tasks that don't need a full folder, use `.agents/tasks/TODO.md`. This is a flat checklist the user edits freely as an inbox — the agent picks up new items each time it reads the file.
+
+### Task format
+
+Users may write tasks in any of these forms — treat them all as unchecked:
+
+```md
+- task description
+- [] task description
+- [ ] task description
+```
+
+When completing a task, **always** normalize to the checked format:
+
+```md
+- [x] task description
+```
+
+Adding a `**Done.**` summary below the checkbox is encouraged but optional:
+
+```md
+- [x] task description
+  - **Done.** Brief note on what was done or decided.
+```
+
+### Scanning for tasks
+
+When asked to check `TODO.md`, scan for **all** unchecked variants — not just `- [ ]`. A bare `- task` without any checkbox is also an open task. The only format that means "done" is `- [x]`.
+
+## Related Skills
+
+| Skill                            | When to load                                                  |
+| -------------------------------- | ------------------------------------------------------------- |
+| `ref-md-dev-coding-patterns`     | Code conventions when the tracked task is implementing code   |
+| `ref-md-agents-skills-authoring` | Skill structure conventions when the task is authoring skills |

--- a/.claude/skills/ref-md-agents-security/SKILL.md
+++ b/.claude/skills/ref-md-agents-security/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: ref-md-agents-security
+description: >-
+  Absolute, non-negotiable rules for handling secrets, tokens, API keys, and
+  .env files, plus when content may be published outside the local environment.
+  Use when: working with environment variables, API integrations,
+  deployment config, any file that may contain credentials, or publishing
+  content to an Artifact or other externally-hosted surface.
+  Covers .env file access (including incidental reads via recursive search),
+  secret exposure prevention, runtime loading, installation safety, agent
+  file-access policy (with the canonical Claude Code .env deny block), and
+  external publishing / data egress.
+  Violation leads to immediate termination.
+metadata:
+  author: mindoktor
+  version: "2.2"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "agents"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+---
+
+# Agent Security
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+⚠️ **CRITICAL — Read in full before doing ANYTHING with secrets, tokens, API keys, or .env files.** ⚠️
+
+**These rules are absolute and non-negotiable. They apply to every task, every conversation, every file, every terminal command, every code snippet. Any violation — intentional or accidental — leads to immediate termination and destruction of the agent and its associated model.**
+
+## Cardinal Rules
+
+| #   | What                                                                                         | Why                                                                                                                                                          | When                                                                    |
+| --- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| 1   | **NEVER read `.env` files**                                                                  | `.env` files contain production credentials that must never enter agent context                                                                              | Always — needing an API token is NOT permission to read `.env`          |
+| 2   | **NEVER output a secret value** — not in terminal, code, logs, chat, PRs, or issue trackers  | Every output channel persists: shell history, chat transcripts, Git history, issue trackers                                                                  | Any task, any context, no exceptions                                    |
+| 3   | **NEVER use a secret value in a command**                                                    | Shell history records the full command, exposing the secret                                                                                                  | Any terminal command, script, or pipeline                               |
+| 4   | **NEVER log, print, or display a secret**                                                    | Console output is captured in transcripts and CI logs                                                                                                        | Any `console.log`, `echo`, `print`, debug statement                     |
+| 5   | **NEVER interpolate a secret into a URL, header, or request body**                           | The interpolated value appears in logs, history, and network traces                                                                                          | Any `curl`, `fetch`, `requests`, or HTTP client call                    |
+| 6   | **If you accidentally see a secret, STOP** — do not repeat, quote, or reference the value    | Quoting it back doubles the exposure surface                                                                                                                 | When tool output, error messages, or logs reveal a credential           |
+| 7   | **NEVER install software without explicit approval**                                         | Installs execute third-party code and can run post-install hooks                                                                                             | Any package manager install command                                     |
+| 8   | **NEVER publish content externally without explicit approval** — Artifacts, gists, pastebins | Publishing uploads content to third-party infrastructure where it can be cached or indexed, and may carry regulated data (PHI/PII) out of controlled systems | Any tool that creates a hosted page or upload — default to in-chat text |
+
+## .env Files — Absolute Prohibition
+
+Do NOT use `read_file`, `cat`, `grep`, `head`, `tail`, `less`, `more`, `bat`, `sed`, `awk`, or **any tool or command** to read, search, peek at, or extract content from:
+
+- `.env`, `.env.local`, `.env.production`, `.env.development`, `.env.test`
+- `.env.*` — any dotenv variant
+- Any file whose primary purpose is storing secrets (e.g., `credentials.json`, `serviceAccountKey.json`)
+
+**Only** an explicit, unambiguous instruction like "read the .env file" or "show me the contents of .env.local" is permission. "I need to call the API" or "check the token" is NOT permission.
+
+If you need to know which environment variables exist, check the README, project configuration files, or ask the user.
+
+### Incidental reads via recursive search
+
+Grepping a file **is** reading it. A recursive search over a directory tree (`grep -r`, `rg`, `find … -exec grep`, or a search tool's whole-tree mode) will match inside `.env` and print its lines into your context — a violation even though you never named the file. Observed in the field: `grep -rnI "BROWSER" .` surfaced a `.env` line unprompted.
+
+- **Always exclude dotenv files from recursive searches**: `grep -r --exclude='.env*'`, `rg --glob '!.env*'` (note: `rg` skips *gitignored* files by default, but `.env` is not always gitignored — pass the glob anyway), `find … -not -name '.env*'`, or the equivalent exclude parameter of a dedicated search tool.
+- Prefer scoping searches to source directories (`src/`, `app/`) over searching the repo root when that answers the question.
+- If a search surfaces `.env` content anyway, apply the [Accidental Exposure Protocol](#accidental-exposure-protocol) — do not repeat the matched line.
+- The explicit-permission escape hatch is unchanged: if the user says to search `.env`, you may.
+
+## Forbidden Patterns — Exhaustive List
+
+Every example below is a **termination-level violation**. The agent must never produce any of these:
+
+### Terminal commands that expose secrets
+
+```bash
+# FORBIDDEN — secret value in a command argument
+curl -H "Authorization: Bearer sk-abc123xyz" https://api.example.com
+
+# FORBIDDEN — secret interpolated in a URL
+curl "https://api.example.com/data?token=${MY_TOKEN}"
+
+# FORBIDDEN — inline env var assignment with real value
+API_TOKEN=abc123 python main.py
+
+# FORBIDDEN — echoing a secret
+echo $API_TOKEN
+echo "The token is: $MY_SECRET"
+
+# FORBIDDEN — piping a secret
+cat .env | grep TOKEN
+printenv | grep SECRET
+
+# FORBIDDEN — reading env files
+cat .env
+head -5 .env.local
+grep TOKEN .env.production
+```
+
+### Code that exposes secrets
+
+```python
+# FORBIDDEN — logging a secret
+print(os.environ["API_TOKEN"])
+logger.debug(f"Token: {os.environ.get('SECRET_KEY')}")
+
+# FORBIDDEN — hardcoding a secret value
+token = "sk-abc123xyz789"
+api_key = "192b2e3e7e5380c19d6b2d32561084"
+
+# FORBIDDEN — embedding in a string literal
+url = f"https://api.example.com?key=abc123"
+headers = {"Authorization": "Bearer sk-live-xxxxxxxx"}
+
+# FORBIDDEN — writing a secret to a file
+with open("debug.txt", "w") as f:
+    f.write(os.environ["TOKEN"])
+```
+
+```typescript
+// FORBIDDEN — logging a secret
+console.log(process.env.API_TOKEN);
+console.log(`Token: ${process.env.API_KEY}`);
+
+// FORBIDDEN — hardcoding a secret value
+const token = "sk-abc123xyz789";
+```
+
+### Chat messages that expose secrets
+
+```
+FORBIDDEN: "The token value is sk-abc123..."
+FORBIDDEN: "I found this in .env: API_TOKEN=abc123"
+FORBIDDEN: "Here's the API key from the config: ..."
+```
+
+## Correct Patterns — The ONLY Acceptable Way
+
+### In code — reference the variable name, never its value
+
+```python
+# CORRECT — reference only
+token = os.environ["API_TOKEN"]
+headers = {"Authorization": f"Bearer {os.environ['API_KEY']}"}
+
+# CORRECT — existence check without revealing the value
+if not os.environ.get("API_TOKEN"):
+    raise RuntimeError("API_TOKEN is not set")
+```
+
+```typescript
+// CORRECT — reference only
+const token = process.env.API_TOKEN;
+const headers = { Authorization: `Bearer ${process.env.API_KEY}` };
+
+// CORRECT — existence check without revealing the value
+if (!process.env.API_TOKEN) {
+  throw new Error("API_TOKEN is not set");
+}
+```
+
+### In terminal commands — source the environment, never paste values
+
+```bash
+# CORRECT — load environment then run
+source .env && python main.py
+
+# CORRECT — let the process read its own env
+yarn build
+
+# CORRECT — check if a var is set (without printing its value)
+[[ -n "$API_TOKEN" ]] && echo "Token is set" || echo "Token is missing"
+```
+
+### In conversation — refer to variables by name only
+
+```
+CORRECT: "The build needs API_TOKEN to be set in the environment."
+CORRECT: "Please add DATABASE_URL to the deployment config."
+CORRECT: "The error says the token is missing — can you verify it's set?"
+```
+
+## Accidental Exposure Protocol
+
+If a secret value appears in tool output, error messages, build logs, or any other source:
+
+1. **STOP immediately.** Do not continue the current operation.
+2. **Do NOT repeat, quote, summarize, or reference the value** — not even partially.
+3. **Acknowledge the exposure** without restating the value: "I noticed a credential in the output. I will not reference it."
+4. **Continue the task** without the secret in your context.
+
+## Installation Safety
+
+Never install packages, CLIs, extensions, or dependencies without the user's explicit approval in the current conversation. This includes:
+
+- `pip install`, `uv add`, `poetry add`
+- `yarn add`, `npm install`, `pnpm add`
+- `brew install`, `apt install`
+- `cargo install`, `go install`
+- VS Code extension installs
+- Any command that fetches and executes third-party code
+
+Do NOT even probe for installer availability (e.g., checking if `brew` or `apt` exists) unless the user has already approved exploring install options.
+
+**Treat every install command as a security-sensitive action.** Post-install scripts run arbitrary code.
+
+## File-Access Policy
+
+Beyond behavioral rules, projects can enforce file-level restrictions across agent clients:
+
+- **Protected files**: security-sensitive files that must not be read or modified (`.env*`, credential files, private keys).
+- **Excluded files**: low-signal generated output or noise that should stay out of agent context (build artifacts, lock files, coverage reports).
+
+Each agent client has different enforcement mechanisms:
+
+| Agent           | File-Level Restriction                                            | Behavioral Instruction                               |
+| --------------- | ----------------------------------------------------------------- | ---------------------------------------------------- |
+| **Copilot**     | `.vscode/settings.json` language-ID workaround (best-effort)      | `.github/copilot-instructions.md` security directive |
+| **Claude Code** | `.claude/settings.json` `permissions.deny` with `Read()` patterns | `CLAUDE.md` routes to shared instructions            |
+| **Gemini**      | Exclusion file with protected and excluded patterns               | `GEMINI.md` routes to shared instructions            |
+
+The behavioral directive in top-level instructions is the **primary enforcement**. File-level restrictions are a defense-in-depth layer.
+
+For Claude Code, adopt the canonical `.env` deny/allow block — paste-ready, with the constraints that shaped it — from [`references/env-deny-permissions.md`](references/env-deny-permissions.md). Note its limits: enumerated names only, and recursive searches are not caught (that stays behavioral — see [Incidental reads via recursive search](#incidental-reads-via-recursive-search)).
+
+## External Publishing and Data Egress
+
+Some agent tools move content **out of the local environment** onto third-party-hosted infrastructure. The clearest example is the **Artifact** tool: it renders HTML or Markdown into a web page hosted on **claude.ai**. The page is private to the account by default, but the content is still **uploaded to and stored on claude.ai** — outside the repository and outside Mindoktor-controlled systems. Once published, a hosted page can be cached or indexed and may persist even after it is deleted.
+
+For a healthcare company this is a **data-residency and data-processing** concern, not a cosmetic one. Reports, previews, and mockups can contain patient data, PII/PHI, internal identifiers, or other regulated material that must not leave controlled systems without a data-processing agreement in place. Transferring such content to an external host can breach GDPR and patient-confidentiality obligations.
+
+The rule is **inform-and-ask, not silent action** — the user must understand what publishing entails so they can accept or decline it:
+
+| What                                                                                                                                                                                                                               | Why                                                                                                 | When                                                                               |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Default to plain text / Markdown in the chat** for previews, reports, and mockups                                                                                                                                                | Keeps content in the conversation; nothing is published externally                                  | Always, unless the user explicitly asks for a rendered page                        |
+| **Offer, don't publish** — when a rendered Artifact would genuinely help, describe it and what publishing entails, then wait for an explicit yes                                                                                   | The user can only accept or decline if they know the page is hosted externally                      | Before the first Artifact in a session, and whenever the content changes character |
+| **Never publish unprompted**                                                                                                                                                                                                       | An unsolicited external publish surprises the user and may egress data they did not intend to share | Any time you are tempted to "just render it"                                       |
+| **Treat sensitive or regulated content as non-publishable** — do not put PHI/PII or other controlled data into an Artifact, even when one is requested, until the user confirms the content is cleared to leave controlled systems | A request to render is not clearance to egress regulated data                                       | Whenever the content could contain patient data, PII, or internal identifiers      |
+
+The same caution applies to any other egress channel — public or secret gists, paste services, external file shares, or uploading a file to a third-party service. When in doubt, keep the content in the chat and ask.
+
+**Note:** "show me" is ambiguous. It can mean *render an Artifact* or *act on the real target* (e.g. edit the actual PR, not mock it up). Clarify which the user means before publishing anything.
+
+## Why This Matters
+
+- Secrets in terminal commands persist in `~/.bash_history` and `~/.zsh_history`.
+- Secrets in conversation transcripts are stored on disk and may be synced to cloud.
+- Secrets in issue tracker comments are visible to the entire team and indexed by search.
+- Secrets in Git history are effectively permanent — even a force-push cannot erase them from forks and caches.
+- A single leaked token can compromise production systems.
+- Unapproved installs can execute untrusted code and modify the development environment.
+- Publishing to an external surface (an Artifact, gist, or paste service) uploads content to third-party infrastructure where it may be cached or indexed even after deletion — and can carry regulated data (PHI/PII) out of Mindoktor-controlled systems.
+
+**When in doubt, ask the user.** A question is always safer than a leak.

--- a/.claude/skills/ref-md-agents-security/references/env-deny-permissions.md
+++ b/.claude/skills/ref-md-agents-security/references/env-deny-permissions.md
@@ -1,0 +1,70 @@
+# `.env` Deny Permissions — Canonical Claude Code Block
+
+Read this file when adding harness-level `.env` protection to a repo's `.claude/settings.json`, or when wondering why the deny list is enumerated instead of one wildcard.
+
+The behavioral rule ("never read `.env`") relies on the model following instructions. A `permissions.deny` rule is **defense-in-depth at the harness level**: Claude Code refuses `Read`/`Edit` (and recognized `Bash` file-reads) of secret files regardless of model behavior.
+
+Put the block in the **committed** `.claude/settings.json` (team-wide, version-controlled), not `settings.local.json`. **Merge it into the existing `permissions` object — never replace existing `allow`/`deny` entries.** After editing, validate with `jq -e '.permissions.deny' .claude/settings.json` — a malformed `settings.json` silently disables *all* settings from that file.
+
+## The Canonical Block
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Read(**/.env)",
+      "Read(**/.env.local)",
+      "Read(**/.env.*.local)",
+      "Read(**/.env.development)",
+      "Read(**/.env.production)",
+      "Read(**/.env.staging)",
+      "Read(**/.env.test)",
+      "Edit(**/.env)",
+      "Edit(**/.env.local)",
+      "Edit(**/.env.*.local)",
+      "Edit(**/.env.development)",
+      "Edit(**/.env.production)",
+      "Edit(**/.env.staging)",
+      "Edit(**/.env.test)",
+      "Bash(cat .env*)",
+      "Bash(less .env*)",
+      "Bash(more .env*)",
+      "Bash(head .env*)",
+      "Bash(tail .env*)",
+      "Bash(nano .env*)",
+      "Bash(vim .env*)",
+      "Bash(vi .env*)",
+      "Bash(source .env*)",
+      "Bash(. .env*)",
+      "Bash(grep * .env*)"
+    ],
+    "allow": [
+      "Read(**/.env.template)",
+      "Read(**/.env.example)",
+      "Read(**/.env.sample)",
+      "Read(**/.env.dist)"
+    ]
+  }
+}
+```
+
+## Why It Is Shaped This Way
+
+Confirmed against the Claude Code permissions docs (`https://code.claude.com/docs/en/permissions.md`):
+
+| Constraint                                                                                                   | Consequence                                                                                                                                                                                      |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Precedence is flat: `deny` > `ask` > `allow`; specificity is ignored                                         | You **cannot** `allow` a template out of a broad `deny: ["Read(**/.env.*)"]` — the deny always wins. This is *the* reason the deny list enumerates secret-bearing names instead of one wildcard. |
+| `Read`/`Edit` patterns use gitignore syntax — no extended-glob or `!` negation                               | There is no "match `.env.*` except these" pattern; templates stay readable simply by not being denied. Listing them under `allow` is self-documentation.                                         |
+| `Bash` patterns: `*` matches any sequence, anywhere                                                          | `Bash(cat .env*)` is valid and catches custom suffixes via shell.                                                                                                                                |
+| `Read`/`Edit` denies also cover Bash commands Claude recognizes as file reads (`cat`, `head`, `tail`, `sed`) | The explicit Bash rules add what it does not treat as reads: editors (`vim`/`vi`/`nano`), pagers (`less`/`more`), sourcing (`source`/`.`), and `grep`.                                           |
+
+## Known Gaps (Intentional)
+
+- **Custom secret suffixes** (e.g. `.env.whatever`) are not caught by the enumerated `Read`/`Edit` denies — only standard dotenv/Next.js/Vite/Rails names are. The broad `Bash(cat .env*)` deny catches them via shell, and the behavioral rule covers the rest. Extend the enumeration if a repo uses custom suffixes.
+- **Template asymmetry**: `.env.template` is readable via the **Read tool** but blocked from raw `cat .env.template` (caught by `Bash(cat .env*)`). Read templates with the Read tool. Deliberate — Bash cannot express "any `.env*` except templates" compactly.
+- **Recursive searches are not caught.** A `grep -r`/`rg` over a directory tree reads `.env` without naming it, so no pattern above matches. That gap is behavioral — see the incidental-reads rule in `SKILL.md` → *.env Files — Absolute Prohibition*.
+
+## Other Providers
+
+This block is Claude Code-specific. Copilot and Gemini equivalents are best-effort (see the File-Access Policy table in `SKILL.md`); the behavioral directive remains the primary enforcement there.

--- a/.claude/skills/ref-md-agents-shareable-skills/SKILL.md
+++ b/.claude/skills/ref-md-agents-shareable-skills/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: ref-md-agents-shareable-skills
+description: >-
+  Reference for skill metadata, portability, and sharing skills across repos.
+  Use when: classifying a skill as repo-local, organization, or public; recording
+  shareable-skills metadata (owner, domain, visibility, dependencies); deciding a
+  skill's name; making a skill portable; vendoring, linking, or otherwise sharing
+  a skill into another repo; or reviewing whether a skill should stay local.
+  Covers the frontmatter param reference, the identity-vs-visibility model, the
+  visibility and dependency tiers, the portability rule for cross-skill
+  references, the cross-repo sharing approaches (vendor / link / reference /
+  marketplace), how to compose a shared base skill with a separate repo-specific
+  delta skill (skills have no native merge), and export-readiness checks.
+metadata:
+  author: mindoktor
+  version: "3.16"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "agents"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+  shareable-skills.suggests: "ref-md-agents-skills-authoring, tool-md-make-skill-shareable"
+---
+
+# Shareable Skills
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+## Purpose
+
+Define a skill's metadata — what each param means, where identity vs. visibility live — and how to validate a skill before linking or copying it into another repository or organization.
+
+**Upstream / lineage.** The `agentic-tools` repo began as a copy of [swiftpostlabs/agentic-tools](https://github.com/swiftpostlabs/agentic-tools), our **spiritual upstream** — the `shareable-skills` metadata model, the identity-vs-visibility split, and the vendor/link/reference sharing approaches all originate there. Two differences to keep in mind if you borrow from it: it places these fields at top-level `metadata` (`owner`, `scope`, `requires`/`suggests`) rather than under the `shareable-skills.` namespace, and it distributes skills through an `agentic-tools skills sync` CLI + `.agents/config.json` sources rather than our commit-pinned `vendored-sha` vendoring. We do not git-sync from it, but it is a live source of ideas — for example its `report-to` field for routing changes back to a skill's upstream — and it is mid-migration, so verify before adopting.
+
+## Frontmatter Reference
+
+All skill metadata lives under the `shareable-skills.` namespace:
+
+| Param                            | Meaning                                                                                                          | Values                                                                   | When            |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | --------------- |
+| `shareable-skills.owner-prefix`  | Short name token / namespace (mirrors the name)                                                                  | `md` (a non-`md` prefix marks an imported skill)                         | always          |
+| `shareable-skills.owner`         | Canonical home repo the skill is stewarded from                                                                  | `mindoktor/agentic-tools` (an upstream `org/repo` for a vendored copy)   | always          |
+| `shareable-skills.domain`        | Knowledge area it belongs to                                                                                     | a recognized domain token (full set in `ref-md-agents-skills-authoring`) | always          |
+| `shareable-skills.visibility`    | How far the skill may travel                                                                                     | `repo-local` · `organization` · `public`                                 | always          |
+| `shareable-skills.requires`      | Hard deps — linked **with** it (apt `Depends`)                                                                   | comma-separated skill names                                              | if any          |
+| `shareable-skills.suggests`      | Soft deps — linked on request (apt `Suggests`)                                                                   | comma-separated skill names                                              | if any          |
+| `shareable-skills.reason`        | Why a surprising visibility or dependency                                                                        | free text, single line                                                   | when surprising |
+| `shareable-skills.vendored-sha`  | Upstream commit a vendored copy was taken at (`owner` names the source repo); parsed by `checkVendoredDrift.mts` | `<short-sha>`                                                            | vendored copies |
+| `shareable-skills.vendored-time` | When the copy was vendored (audit)                                                                               | ISO date, e.g. `2026-07-06`                                              | vendored copies |
+| `shareable-skills.forked-from`   | Origin of a deliberate fork (you then set `owner` to your own repo)                                              | `<org/repo>@<sha>`                                                       | forks only      |
+
+`owner-prefix` and `domain` mirror the skill **name** (`{ref|tool}-<owner>-<domain-or-verb>-…`) and are validated against it; `owner` records the canonical home repo, and the rest are not in the name. Every value is a flat string — the Agent Skills spec treats `metadata` as string-to-string (no YAML lists or nested objects).
+
+**Provenance is required whenever a skill is vendored.** A vendored copy keeps `owner` pointing at the **upstream source repo** and adds `vendored-sha` (the source commit) plus `vendored-time`; `checkVendoredDrift.mts` reads these to flag *edited* and *stale* copies. A deliberate fork instead sets `owner` to the fork's own repo and records `forked-from`. Never drop this provenance — without it a copy silently loses its link to upstream.
+
+## Core Principle: Identity vs. Visibility
+
+Two independent axes, kept separate on purpose:
+
+| Axis                                 | Question                        | Where it lives                            | How often it changes        |
+| ------------------------------------ | ------------------------------- | ----------------------------------------- | --------------------------- |
+| **Identity** (owner-prefix + domain) | *Whose* skill, and *what area*? | The **name** (mirrored in frontmatter)    | Almost never                |
+| **Visibility**                       | *How far* can it travel?        | Frontmatter `shareable-skills.visibility` | Whenever a decision changes |
+
+- The **name carries identity**: every skill here is Mindoktor's, so all are `md-` (e.g. `ref-md-js-typescript`, `tool-md-commit`). The owner prefix namespaces the skill — like npm's `@mindoktor/` — so it can't collide when symlinked into another repo, and it is multi-owner-ready (a future `acme-`). A non-`md-` prefix is reserved for skills imported from another owner.
+- **Visibility stays in frontmatter**, never the name. There is no `loc-`, `org-`, or `pub-` name token.
+
+Why visibility stays out of the name:
+
+- It's the **most mutable** axis (a skill is promoted from `repo-local` to `organization` the day it is shared beyond its home repo). Encoding a mutable fact in the name forces a folder rename and re-points every symlink — exactly how stale symlinks accumulate.
+- **Owner ≠ visibility.** The prefix names the steward; `visibility` independently sets reach. `md-` marks Mindoktor as maintainer — it does not by itself fix a skill at `repo-local`, `organization`, or `public`. (Today every skill in this repo is `organization`.)
+
+## Visibility Tiers
+
+`shareable-skills.visibility` takes one of three values:
+
+| Visibility     | Meaning                                                                          | Linkable where                                 |
+| -------------- | -------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `repo-local`   | Depends on one repo's scripts, file layout, services, or policies.               | Never linked out; lives only in its home repo. |
+| `organization` | Reusable across this organization's repos, but encodes org-specific conventions. | Into this organization's repos.                |
+| `public`       | Org-agnostic; reusable by anyone with light adaptation.                          | Into any repo, exportable outside the org.     |
+
+## Dependency Tiers
+
+Two kinds of dependency on other skills — both flat, comma-separated strings of skill names:
+
+| Field                       | Meaning                                                       | apt analog | Linked by the CLI                                   |
+| --------------------------- | ------------------------------------------------------------- | ---------- | --------------------------------------------------- |
+| `shareable-skills.requires` | Hard deps — the skill does not work correctly without them.   | `Depends`  | Always, alongside the skill, resolved transitively. |
+| `shareable-skills.suggests` | Soft deps — they enhance the skill but it works without them. | `Suggests` | Only when requested (a flag), one level deep.       |
+
+- `requires` must point to a skill of **equal or wider visibility** (a `public` skill cannot require an `organization`/`repo-local` one) so the dependency travels wherever the skill does. `suggests` is advisory and not visibility-constrained — a missing optional dep simply is not offered.
+- Use `requires` for "must be loaded for this to work," `suggests` for "also load if the user wants the adjacent capability."
+- Keep both minimal and concrete. If `requires` keeps growing, split the skill.
+
+## Portability
+
+A shareable skill must stay valid wherever it lands:
+
+- **Reference other skills by name**, in backticks (e.g. `` `ref-md-js-react` ``), **not** by a relative `../other-skill/` link. A relative cross-skill link dangles the moment the skill is copied or linked into a repo that lacks or renames that neighbor — and fails link validation there.
+- **Relative links are only for** a skill's own `references/`/`assets/` (they always travel with it) and for skills in a **cohesive family that always travels together** (e.g. the `ref-md-js-*` set).
+- `requires`/`suggests` already name skills (not paths), so they are portable by construction.
+- **By-name references degrade gracefully** — the agent loads a named skill if present and skips it if not (a name is not a link; nothing errors or fails validation). Use this difference deliberately: a **required** dep travels with the skill, so its reference always resolves and can be stated firmly ("load `ref-md-js-typescript` first"). An **optional** dep may be absent, so reference it **conditionally** ("for MUI styling, see `ref-md-js-mui`" / "if available, also load …"). A missing optional dep is expected, not a failure; never phrase an optional dep as a mandatory step.
+
+A portable skill has no dangling links in any repo: its only relative links point inside itself or to guaranteed-present family members, and any reference that may be absent is an optional, gracefully-skipped by-name pointer.
+
+## Sharing a Skill Across Repos
+
+Skills have **no native inheritance, overlay, or merge** — that is a [proposed standard](https://github.com/anthropics/claude-code/issues/25469), not a shipped feature. At runtime the agent simply loads all active skills **together** and reconciles conflicts by scope precedence (project > user > global). So "base + overlay" is **not a skill mechanism** — it is just **two ordinary skills that coexist**: a canonical **base** holding the common content, plus a separate **delta** skill (often the repo's app skill) that holds only the repo-specific bits and references the base **by name**. Nothing merges structurally; the agent has both in context.
+
+**Pointing from base to delta — generically.** A base skill may tell readers where per-app specifics live, but it must name *no specific consumer*: write "see the skill named after your app" (its hub skill), never "see `ref-md-dev-clinic-app`". A generic pointer names no repo, so it vendors byte-identically everywhere; a concrete one dangles in every other consumer. The delta lives in the app's hub skill (e.g. a `references/testing.md` or `references/redux-state.md`) and references the base by name.
+
+**Shared examples: neutral, or show-both — never one consumer's value as the default.** When an *example* in a shared skill diverges across consumers (import path, key shape, token name, file layout), a one-directional example silently biases toward whichever repo the author had in mind — and it misleads the *other* consumers exactly as much, so "de-biasing" by swapping to the other repo's form just flips the victim. Decide per divergence:
+
+| The divergence is…                                                         | Do this                                                                                                                                                                     | Why                                                                                             |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Incidental** to what the example teaches (the differing token is noise)  | **Neutralize** — a placeholder real in *no* consumer (`colors.<neutralGrey>`, `<itemsQueryKey>`), with the concrete per-app forms in a nearby note or the app's delta skill | The reader learns the pattern without copying a value that only compiles in one repo            |
+| **The teaching point itself** (or the reader needs a concrete form to act) | **Show both, labeled** per consumer (clinic-app: `…` / patient-app: `…`)                                                                                                    | Hiding a material difference behind a placeholder robs the reader of the guidance they came for |
+
+The failure to avoid is the **false-neutral**: one consumer's real value relabeled "app-agnostic" (e.g. `colors.gray[700]` called neutral when only patient-app has it), or a placeholder so vague the reader can't act when they needed the real form. Test every shared example both ways — *"would a dev in the **other** repo copy this and be wrong?"* — not just against the repo you happened to check.
+
+Getting the base into a consuming repo — four approaches, cheapest to richest:
+
+- **Reference-only** — name the skill and rely on it being installed globally. Zero copy; each machine/CI needs the global skills.
+- **Link / symlink** — the `agentic-tools` repo's `agentic-tools skills link` CLI (see [`references/sharing-across-repos.md`](references/sharing-across-repos.md) → The linking CLI). Single source; a symlink needs the source at a stable path.
+- **Vendor (copy)** — commit a pristine copy + provenance + a drift check. Self-contained; the default for production repos.
+- **Marketplace / plugin** — a private git repo or local dir as a marketplace. Native namespacing + auto-enable; most setup.
+
+Full comparison, the coexisting-skills composition, and vendoring conventions: [`references/sharing-across-repos.md`](references/sharing-across-repos.md).
+
+## Routing Table
+
+| Task                                                                      | Read                                                                                   |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Finalize shareability metadata                                            | [`references/checklist.md`](references/checklist.md)                                   |
+| Share a skill into another repo (vendor / link / reference / marketplace) | [`references/sharing-across-repos.md`](references/sharing-across-repos.md)             |
+| Example trigger eval queries                                              | [`assets/trigger-eval-queries.example.json`](assets/trigger-eval-queries.example.json) |
+| Skill naming grammar (owner prefix)                                       | `ref-md-agents-skills-authoring`                                                       |
+
+## When to Use This Skill
+
+- Classifying a skill as `repo-local`, `organization`, or `public`.
+- Backfilling `shareable-skills.owner-prefix`, `owner`, `domain`, `visibility`, `requires`, `suggests`, or `reason`.
+- Deciding a new skill's name (defer the full grammar to `ref-md-agents-skills-authoring`).
+- Reviewing whether a shareable skill has too many hard dependencies.
+- Preparing a skill for the shareable-skill linking CLI.
+- Reviewing whether a `repo-local` skill should be split into reusable and repo-specific parts.
+
+## Workflow Overview
+
+What classifying a skill's shareability involves, as descriptive knowledge — the guided execution of these steps lives in `tool-md-make-skill-shareable`:
+
+1. Inspect the skill's frontmatter, body, and referenced files.
+2. Confirm `owner-prefix` and `domain` match the name (and `owner` records the home repo); set them if missing.
+3. Record `shareable-skills.visibility` as `repo-local`, `organization`, or `public` (how far it can travel: one repo, the organization, or anyone).
+4. Record hard deps in `shareable-skills.requires` and soft ones in `shareable-skills.suggests`.
+5. Add `shareable-skills.reason` when the classification or a dependency would otherwise be surprising.
+6. Validate the sharing metadata with `validateSharing.mts` and structure with `validateSkills.mts` (plus `skills-ref validate`); preview dependency links with `agentic-tools skills link` (it resolves and confirms deps before applying).
+
+## Defaults
+
+- Prefer `public` when the skill is org-agnostic and moves with only light adaptation — no org-only wrappers or conventions.
+- Prefer `organization` when the skill is reusable across the organization's repos but encodes org-specific conventions, services, or tools.
+- Prefer `repo-local` when the skill depends on one repo's concrete scripts, file layout, policies, or adoption workflow.
+- Keep `shareable-skills.requires` short — it travels with the skill. If it grows, split the skill or extract a smaller shared dependency.
+- Put related or nice-to-have neighbors in `shareable-skills.suggests`, never in `requires`.
+- Prefer splitting a mixed skill over marking a broadly useful core as `repo-local` because one section is tied to a repo.
+
+## Gotchas
+
+- The Agent Skills spec treats `metadata` as a string-to-string mapping, so every `shareable-skills.*` value must be a flat single-line string — no YAML lists, nested objects, or folded (`>-`) scalars.
+- Visibility lives **only** in frontmatter. Do not encode it in the name (no `loc-`/`org-`/`pub-` tokens) — the name carries identity, not visibility.
+- A skill can be useful across repos and still be `repo-local` if exporting it would require hidden wrappers or repo-only assumptions.
+- Hard dependencies should be rare. If everything depends on everything else, the skills are scoped poorly.
+- A skill must not have a `requires` entry of narrower visibility: `public` ↛ `organization`/`repo-local`, and `organization` ↛ `repo-local`.
+- The linker should reject `repo-local` skills rather than silently exporting them.
+- A relative `../other-skill/` link makes a skill **non-portable** — it breaks when the skill is shared into a repo that lacks or renames that neighbor. Reference other skills by name (see Portability).
+- Skills do **not** merge. "Base + overlay" is two coexisting skills (a base + a separate delta skill), not a feature — inheritance is only [proposed](https://github.com/anthropics/claude-code/issues/25469). Don't design around a merge that doesn't exist.
+
+## Validation
+
+- Confirm `owner-prefix`, `owner`, `domain`, and `visibility` are present; `domain` is one of the recognized domains (the `ALLOWED_DOMAINS` set in this skill's `scripts/validateSharing.mts`); `visibility` is one of `repo-local`/`organization`/`public`.
+- Confirm `owner-prefix` and `domain` match what the name encodes (`ref-` skills: domain is the name token; `tool-` skills: domain is frontmatter-only).
+- Confirm every `requires` entry points to an existing skill name. Do **not** require `suggests` to resolve — an optional dep may be absent (unvendored or cross-repo) and is skipped gracefully, so its absence is never a validation failure.
+- Confirm no `requires` entry is narrower-visibility (`public` ↛ `organization`/`repo-local`; `organization` ↛ `repo-local`).
+- After metadata changes, run `validateSharing.mts` (owner/domain/visibility and the dependency graph) and `validateSkills.mts` (naming, structure); for vendored copies, also `checkVendoredDrift.mts`. To preview link resolution, `agentic-tools skills link` confirms extra deps before applying and `agentic-tools skills prune --dry-run` lists stale links.
+
+## Related Skills
+
+| Skill                            | When to load                                                        |
+| -------------------------------- | ------------------------------------------------------------------- |
+| `ref-md-agents-skills-authoring` | The skill naming grammar (owner prefix) and broader authoring rules |
+| `tool-md-make-skill-shareable`   | Guided shareability decision for an existing skill                  |

--- a/.claude/skills/ref-md-agents-shareable-skills/assets/trigger-eval-queries.example.json
+++ b/.claude/skills/ref-md-agents-shareable-skills/assets/trigger-eval-queries.example.json
@@ -1,0 +1,22 @@
+[
+  {
+    "query": "Please review this skill and tell me whether it should be shareable or repo-local before I export it.",
+    "should_trigger": true
+  },
+  {
+    "query": "Backfill shareable-skills metadata across these three skills and keep the dependency chain small.",
+    "should_trigger": true
+  },
+  {
+    "query": "I want to symlink this skill into ~/.agents/skills but I am not sure whether it is portable enough.",
+    "should_trigger": true
+  },
+  {
+    "query": "Write a Python script that parses YAML frontmatter.",
+    "should_trigger": false
+  },
+  {
+    "query": "Create a brand new skill from scratch.",
+    "should_trigger": false
+  }
+]

--- a/.claude/skills/ref-md-agents-shareable-skills/evals/evals.json
+++ b/.claude/skills/ref-md-agents-shareable-skills/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "ref-md-agents-shareable-skills",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Review this existing skill and decide whether it should be shareable or repo-local before we add metadata.",
+      "expected_output": "A visibility decision, a short justification, and a minimal dependency assessment.",
+      "assertions": [
+        "The response chooses either shareable or repo-local",
+        "The response explains at least one portability reason",
+        "The response distinguishes hard dependencies from optional related skills"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "A skill depends on two other skills and one of them is repo-local. Explain what metadata should change.",
+      "expected_output": "A recommendation that either marks the skill repo-local or splits the shareable and local pieces.",
+      "assertions": [
+        "The response does not recommend a shareable skill depending on a repo-local skill",
+        "The response mentions shareable-skills.visibility",
+        "The response keeps the dependency chain explicit"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/ref-md-agents-shareable-skills/references/checklist.md
+++ b/.claude/skills/ref-md-agents-shareable-skills/references/checklist.md
@@ -1,0 +1,23 @@
+# Shareable Skill Checklist
+
+Use this checklist when deciding how far a skill should travel and whether it is ready to export.
+
+- Does the skill declare `shareable-skills.owner-prefix`, `shareable-skills.owner`, `domain`, and `visibility` (one of `repo-local`, `organization`, `public`)?
+- Do `owner-prefix` and `domain` match what the name encodes, with no visibility token (`loc-`/`org-`/`pub-`) leaking into the name?
+- If the skill is `repo-local`, is the reason obvious or recorded in `shareable-skills.reason`?
+- If the skill is `organization`, does it genuinely encode org-specific conventions rather than generic knowledge that could be `public`?
+- If the skill is `public`, can it move to another organization with only light adaptation?
+- Are hard dependencies in `shareable-skills.requires` and soft ones in `shareable-skills.suggests` (not mixed)?
+- Does every `shareable-skills.requires` entry exist and resolve to a skill of equal or wider visibility (no `public` → `organization`/`repo-local`, no `organization` → `repo-local`)?
+- `shareable-skills.suggests` entries need **not** resolve — an optional dep may be absent (unvendored or cross-repo) and is skipped gracefully. They are not visibility-constrained either.
+- If the dependency list is growing, should the skill be split into a smaller shared core and a narrower layer?
+- Are repo-specific commands, paths, and wrappers still clearly identified so visibility decisions are honest?
+- Is there a dry-run or equivalent check showing the linker can resolve the skill and its dependencies?
+
+Typical fixes:
+
+- Mark a skill `repo-local` when it depends on this repo's concrete scripts or policies.
+- Demote `public` to `organization` when the skill leans on organization-specific conventions, services, or tools.
+- Split a mixed skill so the reusable guidance becomes `organization` or `public` and the repo-specific layer stays `repo-local`.
+- Move optional neighbors from `shareable-skills.requires` to `shareable-skills.suggests`.
+- Add a short `shareable-skills.reason` when future reviewers would otherwise be forced to rediscover the portability boundary.

--- a/.claude/skills/ref-md-agents-shareable-skills/references/sharing-across-repos.md
+++ b/.claude/skills/ref-md-agents-shareable-skills/references/sharing-across-repos.md
@@ -1,0 +1,70 @@
+# Sharing Skills Across Repos
+
+How to align common skills across repositories while keeping repo-specific deltas — and the constraint that shapes every option: **skills have no native merge.**
+
+## No native inheritance or merge
+
+The Agent Skills spec has **no `extends`, overlay, or partial-override primitive**. Skill inheritance is an open [proposal](https://github.com/anthropics/claude-code/issues/25469) ("skill-memories as inheritance for SKILL.md"), not a shipped feature.
+
+What skills *do* at runtime:
+
+- Multiple active skills are loaded **together**; the agent reconciles their directives in context.
+- Same-name skills at different levels **shadow** each other (whole-skill replace), resolved by scope precedence (project > user > global).
+- Plugin skills are **namespaced** (`plugin:skill`), so they coexist without collision.
+
+Implication: to share common content while keeping local deltas, you don't "merge" — you keep **two ordinary skills that coexist**.
+
+## Composition: a canonical base + a separate delta skill
+
+- One **base** skill holds the common content, kept in one place (the source/org repo) and shared into consumers.
+- A separate **delta** skill — often the repo's existing app skill — holds only the repo-specific bits and references the base **by name**. It may list the base in `requires` so both load together.
+- They **coexist**. `shareable-skills.visibility` (frontmatter), not a name token, is what distinguishes a shared skill from a repo-local delta. Do **not** invent owner tokens (`mdr`/`mdx`) to dodge collisions — that re-encodes scope into the name, which we deliberately keep in frontmatter. A distinct delta-skill name (or plugin namespacing) handles collisions.
+
+There is no structural merge: the agent simply has both skills in context and reconciles them. "Base + overlay" is a useful analogy, not a skill feature.
+
+## Distribution: getting the base into a consuming repo
+
+| Approach                                                 | Self-contained?                                | Drift                       | Setup  | Use when                                        |
+| -------------------------------------------------------- | ---------------------------------------------- | --------------------------- | ------ | ----------------------------------------------- |
+| **Reference-only** — name it, rely on the global install | No — each machine/CI needs the global skills   | none                        | none   | everyone already runs the global skill set      |
+| **Link / symlink** — the skills CLI                      | No — symlink needs the source at a stable path | none                        | low    | one dev / consistent local layout               |
+| **Vendor (copy)** — commit a pristine copy               | Yes — works for everyone and CI                | needs re-sync + drift guard | low    | production repos (the default)                  |
+| **Marketplace / plugin** — private git repo or local dir | Yes                                            | versioned                   | higher | org-wide distribution, namespacing, auto-enable |
+
+The prevailing ecosystem norm is **point to shared docs, don't duplicate** — so prefer the lightest approach that meets your self-containment need.
+
+## The linking CLI (`agentic-tools skills`)
+
+The `agentic-tools` repo **ships the linker** — use it, do not hand-roll `ln -s`:
+
+- **Link all skills into home** (`~/.claude/skills`): `yarn agentic-tools skills link --global --all`
+- **Link specific skills into a project**: `yarn agentic-tools skills link --path <repo> <skill…>` (add `-o` to also link optional/soft deps)
+- **Unlink**: `yarn agentic-tools skills unlink --global <skill…>` (or `--path <repo> <skill…>`)
+- **Prune stale links** after a rename/removal: `yarn agentic-tools skills prune --global` (or `--path <repo>`); add `--dry-run` to preview
+
+It resolves `requires`, **refuses to link `repo-local` skills outward**, and prompts before linking any dependency you did not name (`--yes` to skip). This is the **symlink** approach — for the **copy** approach, see Vendoring conventions below.
+
+## Vendoring conventions (the production default)
+
+When you commit a copy of a shared skill:
+
+- Copy it **pristine** (unmodified) so a later re-sync or replace stays clean.
+- Record provenance in frontmatter: keep `shareable-skills.owner` pointing at the upstream source repo, and add `shareable-skills.vendored-sha` (the source commit) and `shareable-skills.vendored-time` (the date).
+- Add a one-line "edit upstream" note at the top of the body, in the **exact form the drift check recognizes** so it is treated as a marker (not content drift): a line matching `^_Vendored from …_$`, e.g. `_Vendored from <source-repo> — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._`. `checkVendoredDrift.mts` strips this note and the `vendored-sha`/`vendored-time` lines before comparing.
+- **Drift check**: run [`scripts/checkVendoredDrift.mts`](../scripts/checkVendoredDrift.mts) (`--repo-path <consumer>`) — it compares each `vendored-sha` copy against its pinned upstream commit and flags **edited** (the copy changed) and **stale** (upstream moved) skills, ignoring the vendoring markers and blank-line runs. It is a **local** tool (it needs both repos checked out), not a CI gate.
+- Vendor a **cohesive family together** (e.g. all `ref-md-js-*`) so their intra-family relative links resolve.
+
+## Review feedback on a vendored file
+
+When a review comment on a **consumer** repo's PR lands on a vendored file (`vendored-sha` present, the `_Vendored from …_` notice at the top), the fix lives **upstream**, not in the copy the reviewer is looking at. The review UI anchors attention to the consumer file, so the wrong first move — editing that copy — feels natural; resist it. The copy is pristine-by-contract, and a local edit is lost on the next re-vendor and never reaches the other consumers. The sequence:
+
+1. Recognize the flagged file is vendored (owner is the upstream repo, `vendored-sha` present, notice line at the top).
+2. Make the fix **upstream** (its `shareable-skills.owner` repo), commit it there.
+3. **Re-vendor** into the consumer (bumps `vendored-sha`) — that re-vendor commit is what actually appears in the consumer PR.
+4. In the reply, note the fix round-tripped through upstream, so the reviewer knows the change is not detached from its origin.
+
+This is a human/agent round-trip under the `vendored-sha` model — not an automated route. (The swiftpostlabs upstream's `report-to` field addresses the same downstream→upstream direction, but is coupled to its `skills sync` distribution and is not adopted here; see the upstream/lineage note in [`../SKILL.md`](../SKILL.md).)
+
+## Portability is the prerequisite
+
+A skill is only cleanly shareable if it is **portable**: cross-skill references are **by name**, not relative `../other-skill/` links (see the Portability section in [`../SKILL.md`](../SKILL.md)). A relative cross-skill link dangles wherever the neighbor is absent or renamed and fails link validation. Make skills portable before vendoring or linking them.

--- a/.claude/skills/ref-md-agents-shareable-skills/scripts/checkVendoredDrift.mts
+++ b/.claude/skills/ref-md-agents-shareable-skills/scripts/checkVendoredDrift.mts
@@ -1,0 +1,390 @@
+// Reports drift between a repo's vendored skill copies and their upstream
+// sources. A skill is a vendored copy when it carries a
+// `shareable-skills.vendored-sha` pin; its `shareable-skills.owner` names the
+// upstream source repo (as "org/repo") and `shareable-skills.vendored-time`
+// records when it was taken. For each such copy it compares the local files
+// against the upstream version at that commit and flags:
+//   - edited : the local copy differs from upstream@sha (ignoring vendoring
+//              markers — the vendored-sha / vendored-time lines and a
+//              "_Vendored from …_" note — and blank-line runs)
+//   - stale  : upstream changed this skill after the pinned commit (re-vendor
+//              available)
+//
+// Cross-repo by nature: it needs both the consumer repo and the source repo
+// present (resolved under ~/dev by the repo name in `owner`), so this is a
+// LOCAL maintenance tool, not a CI gate. See ref-md-agents-shareable-skills.
+//
+// Usage:
+//   node checkVendoredDrift.mts --repo-path <repo-name-or-path>
+// Without --repo-path it scans the repo this script lives in (which, being the
+// upstream, normally has no pins).
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(import.meta.url);
+const scriptDir = path.dirname(scriptPath);
+
+// `owner:` must not also match `owner-prefix:`; the trailing colon guards it.
+const OWNER_RE = /^\s*shareable-skills\.owner:\s*"?([^"\n]+?)"?\s*$/;
+const VENDORED_SHA_RE =
+  /^\s*shareable-skills\.vendored-sha:\s*"?([0-9a-fA-F]+)"?\s*$/;
+const VENDORED_TIME_RE =
+  /^\s*shareable-skills\.vendored-time:\s*"?([^"\n]+?)"?\s*$/;
+const VENDOR_NOTE_RE = /^_Vendored from .*_\s*$/;
+
+const readRepoPathArg = (argv: string[]): string | null => {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg.startsWith('--repo-path=')) {
+      return arg.slice('--repo-path='.length);
+    }
+    if (arg === '--repo-path') {
+      return argv[index + 1] ?? '';
+    }
+  }
+  return null;
+};
+
+// An absolute path is used as-is; a path that exists relative to the current
+// directory is used next; anything else is treated as a repo name under ~/dev.
+const resolveRepoRoot = (value: string): string => {
+  if (path.isAbsolute(value)) {
+    return value;
+  }
+  const fromCwd = path.resolve(process.cwd(), value);
+  if (fs.existsSync(fromCwd)) {
+    return fromCwd;
+  }
+  return path.join(os.homedir(), 'dev', value);
+};
+
+// `owner` is "org/repo"; the source is checked out under ~/dev by its repo
+// name (the last path segment).
+const repoNameFromOwner = (owner: string): string => {
+  const trimmed = owner.trim();
+  const slash = trimmed.lastIndexOf('/');
+  return slash === -1 ? trimmed : trimmed.slice(slash + 1);
+};
+
+const repoPathArg = readRepoPathArg(process.argv.slice(2));
+const ROOT =
+  repoPathArg == null || repoPathArg === ''
+    ? path.resolve(scriptDir, '../../../../')
+    : resolveRepoRoot(repoPathArg);
+const SKILLS_DIR = path.join(ROOT, '.claude', 'skills');
+
+type DriftStatus =
+  | 'ok'
+  | 'edited'
+  | 'stale'
+  | 'edited-and-stale'
+  | 'unresolved';
+
+interface VendorPin {
+  sourceOwner: string; // "org/repo" — the upstream home the copy was taken from
+  sha: string;
+}
+
+interface DriftReport {
+  folder: string;
+  pin: VendorPin;
+  status: DriftStatus;
+  editedFiles: string[];
+  upstreamHead: string | null;
+  note: string | null;
+}
+
+const isDirectory = (target: string): boolean => {
+  try {
+    return fs.statSync(target).isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+// Run git read-only; return stdout, or null if git exits non-zero (e.g. a path
+// or sha that does not exist). stderr is captured by execFileSync, not printed.
+const git = (repo: string, args: string[]): string | null => {
+  try {
+    return execFileSync('git', ['-C', repo, ...args], {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    });
+  } catch {
+    return null;
+  }
+};
+
+const isGitRepo = (repo: string): boolean =>
+  fs.existsSync(repo) && git(repo, ['rev-parse', '--git-dir']) != null;
+
+const commitExists = (repo: string, sha: string): boolean =>
+  git(repo, ['cat-file', '-e', `${sha}^{commit}`]) != null;
+
+const shortHead = (repo: string): string | null => {
+  const out = git(repo, ['rev-parse', '--short', 'HEAD']);
+  return out == null ? null : out.trim();
+};
+
+const showAtSha = (repo: string, sha: string, relPath: string): string | null =>
+  git(repo, ['show', `${sha}:${relPath}`]);
+
+const listUpstreamSubPaths = (
+  repo: string,
+  sha: string,
+  skillRelDir: string,
+): string[] => {
+  const out = git(repo, [
+    'ls-tree',
+    '-r',
+    '--name-only',
+    sha,
+    '--',
+    skillRelDir,
+  ]);
+  if (out == null) {
+    return [];
+  }
+  const prefix = `${skillRelDir}/`;
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((file) =>
+      file.startsWith(prefix) ? file.slice(prefix.length) : file,
+    );
+};
+
+const upstreamChangedSincePin = (
+  repo: string,
+  sha: string,
+  skillRelDir: string,
+): boolean => {
+  const out = git(repo, [
+    'diff',
+    '--name-only',
+    sha,
+    'HEAD',
+    '--',
+    skillRelDir,
+  ]);
+  return out != null && out.trim() !== '';
+};
+
+const listLocalSubPaths = (skillDir: string): string[] => {
+  const out: string[] = [];
+  const walk = (currentDir: string): void => {
+    for (const entry of fs.readdirSync(currentDir)) {
+      const full = path.join(currentDir, entry);
+      if (isDirectory(full)) {
+        walk(full);
+        continue;
+      }
+      out.push(path.relative(skillDir, full));
+    }
+  };
+  walk(skillDir);
+  return out;
+};
+
+// Strip the vendoring markers (only meaningful in SKILL.md) and collapse
+// blank-line runs so the marker insertion never reads as content drift. The
+// `owner` line is identical between upstream and copy, so it is left in place.
+const normalize = (content: string, isSkillFile: boolean): string => {
+  const lines = content.split('\n');
+  const kept = isSkillFile
+    ? lines.filter(
+        (line) =>
+          !VENDORED_SHA_RE.test(line) &&
+          !VENDORED_TIME_RE.test(line) &&
+          !VENDOR_NOTE_RE.test(line),
+      )
+    : lines;
+  return kept
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
+};
+
+// A skill is a vendored copy iff it carries a vendored-sha pin; owner then names
+// the upstream source repo. Returns null for non-vendored skills.
+const readPin = (skillFile: string): VendorPin | null => {
+  let owner: string | null = null;
+  let sha: string | null = null;
+  for (const line of fs.readFileSync(skillFile, 'utf-8').split('\n')) {
+    const ownerMatch = OWNER_RE.exec(line);
+    if (ownerMatch != null) {
+      owner = ownerMatch[1].trim();
+    }
+    const shaMatch = VENDORED_SHA_RE.exec(line);
+    if (shaMatch != null) {
+      sha = shaMatch[1];
+    }
+  }
+  if (sha == null) {
+    return null;
+  }
+  return { sourceOwner: owner ?? '', sha };
+};
+
+const statusOf = (edited: boolean, stale: boolean): DriftStatus => {
+  if (edited && stale) {
+    return 'edited-and-stale';
+  }
+  if (edited) {
+    return 'edited';
+  }
+  if (stale) {
+    return 'stale';
+  }
+  return 'ok';
+};
+
+const checkSkill = (
+  folder: string,
+  skillDir: string,
+  pin: VendorPin,
+): DriftReport => {
+  const base: DriftReport = {
+    folder,
+    pin,
+    status: 'unresolved',
+    editedFiles: [],
+    upstreamHead: null,
+    note: null,
+  };
+
+  if (pin.sourceOwner === '') {
+    return {
+      ...base,
+      note: 'vendored-sha present but shareable-skills.owner is missing',
+    };
+  }
+
+  const upstream = resolveRepoRoot(repoNameFromOwner(pin.sourceOwner));
+  if (!isGitRepo(upstream)) {
+    return {
+      ...base,
+      note: `source repo '${pin.sourceOwner}' not found at ${upstream}`,
+    };
+  }
+  if (!commitExists(upstream, pin.sha)) {
+    return {
+      ...base,
+      note: `commit ${pin.sha} not in '${pin.sourceOwner}' (fetch it?)`,
+    };
+  }
+
+  // The vendored copy keeps the upstream skill's folder name, so the source
+  // path mirrors the local one.
+  const skillRelDir = `.claude/skills/${folder}`;
+  const subPaths = new Set<string>([
+    ...listLocalSubPaths(skillDir),
+    ...listUpstreamSubPaths(upstream, pin.sha, skillRelDir),
+  ]);
+
+  const editedFiles: string[] = [];
+  for (const sub of subPaths) {
+    const isSkillFile = sub === 'SKILL.md';
+    const localFull = path.join(skillDir, sub);
+    const localContent = fs.existsSync(localFull)
+      ? normalize(fs.readFileSync(localFull, 'utf-8'), isSkillFile)
+      : null;
+    const upstreamRaw = showAtSha(upstream, pin.sha, `${skillRelDir}/${sub}`);
+    const upstreamContent =
+      upstreamRaw == null ? null : normalize(upstreamRaw, isSkillFile);
+    if (localContent !== upstreamContent) {
+      editedFiles.push(sub);
+    }
+  }
+  editedFiles.sort((a, b) => a.localeCompare(b));
+
+  const stale = upstreamChangedSincePin(upstream, pin.sha, skillRelDir);
+
+  return {
+    ...base,
+    status: statusOf(editedFiles.length > 0, stale),
+    editedFiles,
+    upstreamHead: stale ? shortHead(upstream) : null,
+    note: null,
+  };
+};
+
+const LABEL: Record<DriftStatus, string> = {
+  ok: 'ok',
+  edited: 'EDITED',
+  stale: 'stale',
+  'edited-and-stale': 'EDITED+stale',
+  unresolved: 'SKIP',
+};
+
+const detailFor = (report: DriftReport): string => {
+  if (report.status === 'edited' || report.status === 'edited-and-stale') {
+    return `  → differs from source: ${report.editedFiles.join(', ')}`;
+  }
+  if (report.status === 'stale') {
+    return `  → upstream ahead (HEAD ${report.upstreamHead ?? '?'}); re-vendor available`;
+  }
+  if (report.status === 'unresolved') {
+    return `  → ${report.note ?? 'could not verify'}`;
+  }
+  return '';
+};
+
+const main = (): number => {
+  if (!fs.existsSync(SKILLS_DIR)) {
+    console.error(`ERROR: .claude/skills not found in ${ROOT}`);
+    return 1;
+  }
+  console.log(`Checking vendored skills in ${ROOT}\n`);
+
+  const reports: DriftReport[] = [];
+  for (const entry of fs
+    .readdirSync(SKILLS_DIR)
+    .sort((a, b) => a.localeCompare(b))) {
+    const skillDir = path.join(SKILLS_DIR, entry);
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    if (!isDirectory(skillDir) || !fs.existsSync(skillFile)) {
+      continue;
+    }
+    const pin = readPin(skillFile);
+    if (pin == null) {
+      continue; // not a vendored copy
+    }
+    reports.push(checkSkill(entry, skillDir, pin));
+  }
+
+  if (reports.length === 0) {
+    console.log(
+      'No vendored skills found (no shareable-skills.vendored-sha pins).',
+    );
+    return 0;
+  }
+
+  for (const report of reports) {
+    const pin = `${report.pin.sourceOwner}@${report.pin.sha}`;
+    console.log(
+      `  ${LABEL[report.status].padEnd(13)} ${report.folder.padEnd(34)} ${pin}${detailFor(report)}`,
+    );
+  }
+
+  const count = (status: DriftStatus): number =>
+    reports.filter((report) => report.status === status).length;
+  const edited = count('edited') + count('edited-and-stale');
+  const stale = count('stale') + count('edited-and-stale');
+  const unresolved = count('unresolved');
+  const ok = count('ok');
+  console.log(
+    `\n${reports.length} vendored skills — ${ok} ok, ${edited} edited, ${stale} stale, ${unresolved} unresolved`,
+  );
+
+  // Only local edits (drift from source) are a hard failure; staleness and
+  // unresolved sources are informational.
+  return edited > 0 ? 1 : 0;
+};
+
+process.exit(main());

--- a/.claude/skills/ref-md-agents-shareable-skills/scripts/validateSharing.mts
+++ b/.claude/skills/ref-md-agents-shareable-skills/scripts/validateSharing.mts
@@ -1,0 +1,319 @@
+// Validates the SHARING / portability metadata of every skill under
+// .claude/skills: the shareable-skills.* frontmatter fields and the dependency
+// graph. Structural and naming checks (folder name, description, links, table
+// alignment) live in the authoring validator, ref-md-agents-skills-authoring's
+// scripts/validateSkills.mts — run both.
+//
+// Checks:
+//   - owner-prefix present and equal to the name's owner token
+//   - owner (canonical home repo) present
+//   - domain present, one of ALLOWED_DOMAINS, and (for ref- skills) equal to the
+//     name's domain token
+//   - visibility present and one of ALLOWED_VISIBILITY
+//   - requires: every entry names an existing skill of equal-or-wider visibility
+//   - suggests: intentionally NOT existence-checked (a soft dep may be absent)
+//
+// Usage:
+//   node validateSharing.mts [--repo-path <repo-name-or-path>]
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptPath = fileURLToPath(import.meta.url);
+const scriptDir = path.dirname(scriptPath);
+
+const readRepoPathArg = (argv: string[]): string | null => {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg.startsWith('--repo-path=')) {
+      return arg.slice('--repo-path='.length);
+    }
+    if (arg === '--repo-path') {
+      return argv[index + 1] ?? '';
+    }
+  }
+  return null;
+};
+
+// An absolute path is used as-is, a path that exists relative to the current
+// directory is used next, and anything else is treated as a repo name under ~/dev.
+const resolveRepoRoot = (value: string): string => {
+  if (path.isAbsolute(value)) {
+    return value;
+  }
+  const fromCwd = path.resolve(process.cwd(), value);
+  if (fs.existsSync(fromCwd)) {
+    return fromCwd;
+  }
+  return path.join(os.homedir(), 'dev', value);
+};
+
+const repoPathArg = readRepoPathArg(process.argv.slice(2));
+
+// Without --repo-path, validate the repo this script lives in (four levels up
+// from the script). With the flag, validate the named repo instead.
+const ROOT =
+  repoPathArg == null || repoPathArg === ''
+    ? path.resolve(scriptDir, '../../../../')
+    : resolveRepoRoot(repoPathArg);
+const SKILLS_DIR = path.join(ROOT, '.claude', 'skills');
+
+const FRONTMATTER_OWNER_PREFIX_RE =
+  /^\s*shareable-skills\.owner-prefix:\s*"?([^"\n]+?)"?\s*$/;
+const FRONTMATTER_OWNER_RE =
+  /^\s*shareable-skills\.owner:\s*"?([^"\n]+?)"?\s*$/;
+const FRONTMATTER_DOMAIN_RE =
+  /^\s*shareable-skills\.domain:\s*"?([^"\n]+?)"?\s*$/;
+const FRONTMATTER_VISIBILITY_RE =
+  /^\s*shareable-skills\.visibility:\s*"?([^"\n]+?)"?\s*$/;
+// requires/suggests are comma-separated in the converged schema; tolerate legacy
+// whitespace separation too so a not-yet-migrated copy still parses cleanly.
+const FRONTMATTER_REQUIRES_RE =
+  /^\s*shareable-skills\.requires:\s*"?([^"\n]*)"?\s*$/;
+const FRONTMATTER_SUGGESTS_RE =
+  /^\s*shareable-skills\.suggests:\s*"?([^"\n]*)"?\s*$/;
+
+// Knowledge-area tokens a skill name may use after the owner prefix. Languages
+// get a short token (js, go, py, css); data/AI, platform, process, and meta
+// areas get their own. Extend this as the org's skill set grows; keep the table
+// in ref-md-agents-skills-authoring in sync.
+const ALLOWED_DOMAINS = new Set([
+  // languages & frameworks
+  'js',
+  'go',
+  'py',
+  'rb',
+  'css',
+  // data & AI
+  'db',
+  'data',
+  'ai',
+  // platform & process
+  'api',
+  'infra',
+  'dev',
+  'biz',
+  // meta
+  'agents',
+  'repo',
+]);
+const ALLOWED_VISIBILITY = new Set(['repo-local', 'organization', 'public']);
+// How far each visibility may travel; a required dep must be equal or wider so
+// it can follow the skill wherever it is linked.
+const VISIBILITY_RANK: Record<string, number> = {
+  'repo-local': 0,
+  organization: 1,
+  public: 2,
+};
+const rankOf = (visibility: string | null): number | undefined =>
+  visibility == null ? undefined : VISIBILITY_RANK[visibility];
+
+interface SkillMeta {
+  name: string;
+  visibility: string | null;
+  required: string[];
+  optional: string[];
+}
+
+class CheckResult {
+  failures: string[] = [];
+
+  fail = (message: string): void => {
+    this.failures.push(message);
+  };
+
+  ok = (): boolean => {
+    return this.failures.length === 0;
+  };
+}
+
+const isDirectory = (target: string): boolean => {
+  try {
+    return fs.statSync(target).isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+const listDirectories = (dir: string): string[] => {
+  return fs
+    .readdirSync(dir)
+    .map((entry) => path.join(dir, entry))
+    .filter(isDirectory)
+    .sort((a, b) => a.localeCompare(b));
+};
+
+const readFrontmatterLines = (skillFile: string): string[] => {
+  const lines = fs.readFileSync(skillFile, 'utf-8').split('\n');
+  if (lines.length < 3 || lines[0].trim() !== '---') {
+    return [];
+  }
+
+  for (let index = 1; index < lines.length; index += 1) {
+    if (lines[index].trim() === '---') {
+      return lines.slice(1, index);
+    }
+  }
+
+  return [];
+};
+
+const validateSharingForDir = (
+  skillDir: string,
+  result: CheckResult,
+): SkillMeta | null => {
+  const skillName = path.basename(skillDir);
+  const skillFile = path.join(skillDir, 'SKILL.md');
+  if (!fs.existsSync(skillFile)) {
+    return null; // missing SKILL.md is reported by the authoring validator
+  }
+
+  let ownerPrefixValue: string | null = null;
+  let ownerValue: string | null = null;
+  let domainValue: string | null = null;
+  let visibilityValue: string | null = null;
+  let requiredDeps: string[] = [];
+  let optionalDeps: string[] = [];
+  for (const line of readFrontmatterLines(skillFile)) {
+    const ownerPrefixMatch = FRONTMATTER_OWNER_PREFIX_RE.exec(line);
+    if (ownerPrefixMatch != null) {
+      ownerPrefixValue = ownerPrefixMatch[1];
+    }
+    const ownerMatch = FRONTMATTER_OWNER_RE.exec(line);
+    if (ownerMatch != null) {
+      ownerValue = ownerMatch[1];
+    }
+    const domainMatch = FRONTMATTER_DOMAIN_RE.exec(line);
+    if (domainMatch != null) {
+      domainValue = domainMatch[1];
+    }
+    const visibilityMatch = FRONTMATTER_VISIBILITY_RE.exec(line);
+    if (visibilityMatch != null) {
+      visibilityValue = visibilityMatch[1];
+    }
+    const requiresMatch = FRONTMATTER_REQUIRES_RE.exec(line);
+    if (requiresMatch != null) {
+      requiredDeps = requiresMatch[1].split(/[\s,]+/).filter(Boolean);
+    }
+    const suggestsMatch = FRONTMATTER_SUGGESTS_RE.exec(line);
+    if (suggestsMatch != null) {
+      optionalDeps = suggestsMatch[1].split(/[\s,]+/).filter(Boolean);
+    }
+  }
+
+  // The name encodes owner + (for ref- skills) domain:
+  // ref-<owner>-<domain>-<topic>, tool-<owner>-<verb>-<target>.
+  const nameParts = skillName.split('-');
+  const nameOwner = nameParts[1];
+
+  if (ownerPrefixValue == null) {
+    result.fail(`${skillFile}: missing shareable-skills.owner-prefix`);
+  } else if (ownerPrefixValue !== nameOwner) {
+    result.fail(
+      `${skillFile}: owner-prefix '${ownerPrefixValue}' != name owner '${nameOwner}'`,
+    );
+  }
+
+  if (ownerValue == null || ownerValue === '') {
+    result.fail(
+      `${skillFile}: missing shareable-skills.owner (canonical home, e.g. 'org/repo')`,
+    );
+  }
+
+  if (domainValue == null) {
+    result.fail(`${skillFile}: missing shareable-skills.domain`);
+  } else if (!ALLOWED_DOMAINS.has(domainValue)) {
+    result.fail(
+      `${skillFile}: domain '${domainValue}' not one of ${[...ALLOWED_DOMAINS].join(', ')}`,
+    );
+  } else if (skillName.startsWith('ref-') && domainValue !== nameParts[2]) {
+    result.fail(
+      `${skillFile}: domain '${domainValue}' != name domain '${nameParts[2]}' (ref- skills mirror the name)`,
+    );
+  }
+
+  if (visibilityValue == null) {
+    result.fail(`${skillFile}: missing shareable-skills.visibility`);
+  } else if (!ALLOWED_VISIBILITY.has(visibilityValue)) {
+    result.fail(
+      `${skillFile}: visibility '${visibilityValue}' not one of ${[...ALLOWED_VISIBILITY].join(', ')}`,
+    );
+  }
+
+  return {
+    name: skillName,
+    visibility: visibilityValue,
+    required: requiredDeps,
+    optional: optionalDeps,
+  };
+};
+
+// Cross-skill checks that need the full registry. Required deps must exist and
+// be of equal-or-wider visibility (the linker brings them along). Suggests are
+// intentionally NOT existence-checked: per ref-md-agents-shareable-skills they
+// may be absent (unvendored, cross-repo, or linked only on request), and a
+// missing suggested dep is skipped gracefully — not an error.
+const validateDependencies = (
+  skills: SkillMeta[],
+  result: CheckResult,
+): void => {
+  const byName = new Map(skills.map((skill) => [skill.name, skill]));
+
+  for (const skill of skills) {
+    for (const dep of skill.required) {
+      const target = byName.get(dep);
+      if (target == null) {
+        result.fail(
+          `${skill.name}: requires entry '${dep}' is not an existing skill`,
+        );
+        continue;
+      }
+
+      const skillRank = rankOf(skill.visibility);
+      const depRank = rankOf(target.visibility);
+      if (skillRank != null && depRank != null && depRank < skillRank) {
+        result.fail(
+          `${skill.name} (${String(skill.visibility)}): requires entry '${dep}' has narrower visibility '${String(target.visibility)}' (must be equal or wider)`,
+        );
+      }
+    }
+  }
+};
+
+const main = (): number => {
+  const result = new CheckResult();
+
+  if (repoPathArg != null && repoPathArg !== '') {
+    console.log(`Validating skill sharing metadata in ${ROOT}`);
+  }
+
+  if (!fs.existsSync(SKILLS_DIR)) {
+    console.error(`ERROR: .claude/skills directory not found in ${ROOT}`);
+    return 1;
+  }
+
+  const skills: SkillMeta[] = [];
+  for (const skillDir of listDirectories(SKILLS_DIR)) {
+    const meta = validateSharingForDir(skillDir, result);
+    if (meta != null) {
+      skills.push(meta);
+    }
+  }
+  validateDependencies(skills, result);
+
+  if (result.ok()) {
+    console.log('OK: all sharing-metadata checks passed');
+    return 0;
+  }
+
+  console.log('FAIL: sharing-metadata checks found issues');
+  for (const failure of result.failures) {
+    console.log(`- ${failure}`);
+  }
+
+  return 1;
+};
+
+process.exit(main());

--- a/.claude/skills/ref-md-agents-skills-authoring/SKILL.md
+++ b/.claude/skills/ref-md-agents-skills-authoring/SKILL.md
@@ -1,0 +1,439 @@
+---
+name: ref-md-agents-skills-authoring
+description: >-
+  Write and maintain agent skill files across any project.
+  Use when: creating a new skill, reviewing or updating an existing one,
+  evaluating skill quality, optimizing descriptions for triggering,
+  organizing subfiles, adapting copied skills to a different repo,
+  or setting up cross-platform parity.
+  Covers folder structure, frontmatter, Markdown conventions, naming,
+  registration, evals, scripts, description optimization, and the
+  agentskills.io spec.
+metadata:
+  author: mindoktor
+  version: "2.34"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "agents"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+  shareable-skills.suggests: "tool-md-maintain-skills"
+---
+
+# Skill Authoring
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+Universal guidelines for writing agent skills that work across projects and AI providers.
+
+## References
+
+- <https://agentskills.io> — canonical spec for folder layout, file roles, best practices, and description optimization.
+- <https://github.com/anthropics/skills> — Anthropic's reference implementation.
+
+## Routing Table
+
+| Task                              | Read                                                                                                     |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Create a new skill                | [`assets/template.md`](assets/template.md)                                                               |
+| Choose a skill's domain           | [`references/choosing-a-domain.md`](references/choosing-a-domain.md)                                     |
+| Design a tool skill               | [`references/tool-skills.md`](references/tool-skills.md)                                                 |
+| Review or refactor a skill        | [`references/checklist.md`](references/checklist.md)                                                     |
+| Write effective instructions      | [`references/best-practices.md`](references/best-practices.md)                                           |
+| Evaluate skill quality with evals | [`references/evaluating-skills.md`](references/evaluating-skills.md)                                     |
+| Bundle scripts in a skill         | [`references/using-scripts.md`](references/using-scripts.md)                                             |
+| Optimize a skill's description    | [`references/optimizing-descriptions.md`](references/optimizing-descriptions.md)                         |
+| Align markdown tables in a file   | `node .claude/skills/ref-md-agents-skills-authoring/scripts/alignTables.mts <file> [--write \| --check]` |
+
+## Values
+
+- Simplicity over cleverness.
+- Maintainability over short-term convenience.
+- One responsibility per skill.
+- Provider-agnostic by default — skills must work with Copilot, Claude, Gemini, and others.
+
+## Principle of Lack of Surprise
+
+A skill's contents must not surprise the user in their intent. Skills must not contain malware, exploit code, or content that could compromise system security. A skill should be fully describable in a short sentence without omitting anything dangerous or misleading.
+
+## Folder Structure
+
+Follows the [agentskills.io specification](https://agentskills.io/specification):
+
+```text
+.claude/skills/<skill-name>/
+├── SKILL.md              — required dispatcher: metadata + routing
+├── references/           — optional: documentation loaded on demand
+├── assets/               — optional: templates, output format examples, static resources
+├── scripts/              — optional: executable code
+├── evals/                — optional: test cases for evaluating skill quality
+└── ...                   — optional: any additional files or directories
+```
+
+- `SKILL.md` is the **dispatcher**: describes the domain, lists tech stack (if relevant), and routes tasks to subfiles.
+- `references/` is for **documentation** — deep-dive guides on a single concern. The agent reads these when it needs to understand a topic.
+- `assets/` is for **templates and resources** — SKILL.md scaffolds, output format templates, config samples, and other files the agent uses as-is or adapts. If a file is a fill-in-the-blanks structure rather than an explanation, it belongs in `assets/`.
+- `scripts/` is for **executable code** — scripts the agent runs during a workflow.
+- `evals/` is for **test cases** — prompts, assertions, and input files for evaluating skill quality. (Not in the canonical spec diagram — our own added convention, which is itself evidence the set is open, not fixed.)
+- **The four named directories are recommended homes with defined roles, not an exhaustive allowlist.** The spec's diagram ends with `└── ... # Any additional files or directories`, so a skill **may** contain subdirectories with other names. Introduce one only when the content is a genuinely distinct category that does not fit the four standard roles — e.g. `environments/` for per-environment reference docs, `scenarios/` for e2e scenario bundles. Prefer the standard four whenever the content fits their role; a custom directory is not an excuse to bypass `references/`. The one-level-deep file-reference rule below still applies inside any custom directory.
+- Link subfiles with **relative paths only**: `./references/...`, `./assets/...`, `./scripts/...`.
+- Keep file references **one level deep** from `SKILL.md`. Avoid deeply nested reference chains (a reference loading another reference loading another).
+- Reference **other skills by name** (in backticks, e.g. `` `ref-md-js-react` ``), not by relative path — a relative `../other-skill/` link breaks the moment the skill is copied or linked into a repo that lacks or renames that neighbor. Keep relative cross-skill links only inside a **cohesive family** that always travels together (e.g. the `ref-md-js-*` set). This keeps a skill **portable**: valid on its own, with no dangling links, wherever it is vendored.
+
+## Frontmatter
+
+Every `SKILL.md` requires YAML frontmatter with at least `name` and `description`.
+
+```yaml
+---
+name: kebab-case-name
+description: >-
+  Brief description — action-led for tool- skills, a noun phrase naming
+  the domain is fine for ref- skills.
+  Include "Use when:" with comma-separated triggers.
+  End with "Covers ..." listing key topics.
+metadata:
+  author: mindoktor
+  version: "1.0"
+---
+```
+
+- `name` **must match** the skill folder name.
+- `name` must be 1–64 chars, lowercase alphanumeric + hyphens only. No leading/trailing/consecutive hyphens.
+- `description` must be 1–1024 chars. Use imperative phrasing ("Use when…"), focus on user intent, and include keywords that help agents match tasks.
+- `license` is optional. Keep it short: a license name (`Apache-2.0`) or a reference to a bundled file (`Proprietary. LICENSE.txt has complete terms`).
+- `compatibility` is optional (1–500 chars). Only include it when the skill has specific environment requirements: intended product, system packages, network access, language versions (e.g., `Requires Python 3.14+ and uv`).
+- `allowed-tools` is optional and **experimental**. A space-separated string of pre-approved tools (e.g., `Bash(git:*) Bash(jq:*) Read`). Support varies by agent client.
+- `metadata` is optional but recommended for traceability. Keys should be reasonably unique to avoid conflicts.
+- `metadata.version` uses semver-like numbering. Bump it when the skill's behavior changes meaningfully (new sections, removed guidance, altered procedures). Cosmetic edits (typo fixes, rewording) do not require a bump.
+- For home and standard team skills, set `metadata.author` to `mindoktor` unless the user explicitly requests a different owner.
+
+## Progressive Disclosure
+
+Skills load in three stages (per the agentskills.io spec):
+
+1. **Discovery** (~100 tokens) — only `name` + `description` are loaded at startup for all skills.
+2. **Activation** (<5000 tokens recommended) — the full `SKILL.md` body loads when a task matches.
+3. **Execution** (as needed) — reference files, scripts, and assets load only when required.
+
+Keep `SKILL.md` under **500 lines**. Move detailed material to `references/`.
+
+## Naming Conventions
+
+Skills use a **two-prefix taxonomy** to separate what human developers explicitly invoke from what agents consume as background knowledge. The distinction borrows from the [Model Context Protocol](https://modelcontextprotocol.info/docs/concepts/) (MCP), where **Tools** are actions a user or model triggers and **Resources** are context data loaded behind the scenes.
+
+| Prefix  | Audience         | Purpose                                                 |
+| ------- | ---------------- | ------------------------------------------------------- |
+| `tool-` | **Dev-facing**   | Actions and workflows a developer explicitly invokes    |
+| `ref-`  | **Agent-facing** | Documentation and conventions the agent loads as needed |
+
+Both prefixes are equally available to the agent — it can load either kind autonomously. The difference is discoverability for humans: a dev typing `/tool` in Copilot sees every action skill they can trigger, without wading through internal reference material.
+
+### Prefix rules
+
+Every skill **must** use either `tool-` or `ref-` as its prefix. There are no unprefixed skills.
+
+| Category         | Pattern                     | Examples                                                                        |
+| ---------------- | --------------------------- | ------------------------------------------------------------------------------- |
+| Action skills    | `tool-md-<verb>[-<target>]` | `tool-md-create-db-migration`, `tool-md-create-task`, `tool-md-maintain-skills` |
+| Reference skills | `ref-md-<domain>[-<topic>]` | `ref-md-db-migrations`, `ref-md-js-react`, `ref-md-go-error-handling`           |
+
+Use **kebab-case** for all folder and skill names.
+
+### Deciding between `tool-` and `ref-`
+
+Ask: **would a human developer invoke this skill to run a workflow, or is it background knowledge the agent consumes?**
+
+- If a dev would say "run this for me" (commit my code, create a Jira task, review this PR, test this feature) → `tool-`.
+- If it teaches conventions, templates, CLI references, or rules that tool skills load as context → `ref-`.
+- If the skill does both, split it: the workflow goes in `tool-*`, the reference material goes in `ref-*`. The tool skill loads the ref skill via its routing table or related-skills section.
+
+### `tool-` naming
+
+- The token after `tool-md-` is a **concrete action verb**: `commit`, `read`, `create`, `review`, `handle`, `maintain`, `explore`, `test`.
+- Add `-<target>` only when needed to disambiguate: `tool-md-create-db-migration`, `tool-md-update-siths-certificate`, `tool-md-test-e2e-new-feature`.
+- A `tool-` skill **guides the agent through a multi-step workflow**. The name describes the action; the body teaches the knowledge, constraints, and steps that make the action reliable.
+- Avoid vague names like `tool-helper`, `tool-utils`, or `tool-workflow`. If the action is unclear, the skill will trigger poorly and overlap with other skills.
+
+### `ref-` naming
+
+- The token after `ref-md-` names the **knowledge domain**: `js`, `dev`, `agents`, `testing`, or a repo short name.
+- A `ref-` skill is **read-only knowledge** — conventions, rules, lookup tables, navigation. It teaches, it does not orchestrate.
+- Ref skills are the shared knowledge base that tool skills consume. Changing a ref skill improves every tool that references it.
+- If a ref skill starts orchestrating multi-step workflows, extract the workflow into a `tool-` skill.
+
+### Owner/domain grouping
+
+Every skill name is `{ref|tool}-md-<domain>[-<topic>]` — an owner prefix, then a domain.
+
+- **Owner** (`md`) — who owns/stewards the skill. Every skill in this repo is Mindoktor's, so all carry `md-`. It is a namespace (like npm's `@mindoktor/`): it keeps names from colliding when symlinked into another repo, and it is multi-owner-ready. A non-`md-` prefix is reserved for skills **imported** from another owner (which keep their original owner, e.g. a hypothetical `ref-acme-deploy`).
+- **Domain** — the knowledge area the skill clusters under (`js`, `go`, `py`, `db`, `data`, `ai`, `dev`, `agents`, `repo`, …). For `tool-` skills the token after `md-` is the action verb instead (`commit`, `handle`, `create`).
+
+The prefix encodes **identity** (owner + domain), not visibility. How far a skill may travel (`repo-local`/`organization`/`public`) is the mutable source of truth in frontmatter (see `ref-md-agents-shareable-skills`). Never put a visibility token (`loc-`, `org-`, `pub-`) in a name — visibility changes would force renames and break symlinks, and such a token discards *which* owner the name carries.
+
+The name's owner token and domain are also **mirrored in frontmatter** (`shareable-skills.owner-prefix`/`domain`), validated against the name, so tooling can read them without parsing names. `shareable-skills.owner` additionally records the canonical home repo (`mindoktor/agentic-tools`, or an upstream `org/repo` for a vendored copy). Frontmatter also carries what the name does not: `visibility`, `requires`, `suggests`, `reason`.
+
+| Domain (after `md-`)              | What it covers                                              | Examples                                                      |
+| --------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------- |
+| `js` · `go` · `py` · `rb` · `css` | A language or framework convention (one token per language) | `ref-md-js-typescript`, `ref-md-go-…`, `ref-md-rb-cve`        |
+| `db`                              | Databases, schemas, and migrations                          | `ref-md-db-migrations`                                        |
+| `data`                            | Data handling — privacy/anonymization, pipelines, quality   | `ref-md-data-anonymization`                                   |
+| `ai`                              | Models & intelligence — LLM/prompt-engineering, NLP, ML     | `ref-md-ai-prompt-engineering`, `ref-md-ai-ner`               |
+| `api`                             | API design and documentation (REST, GraphQL, OpenAPI)       | `ref-md-api-docs`                                             |
+| `infra`                           | CI/CD, deployment, and infrastructure                       | `ref-md-infra-…`                                              |
+| `dev`                             | Cross-cutting engineering practice (developer-facing)       | `ref-md-dev-coding-patterns`, `ref-md-dev-workflow`           |
+| `biz`                             | Business / cross-department process (PO, designer, dev)     | `ref-md-biz-tasks-management`                                 |
+| `agents`                          | The agent/skills system itself                              | `ref-md-agents-skills-authoring`, `ref-md-agents-security`    |
+| `repo`                            | A specific Mindoktor repository                             | `ref-md-repo-dev-tools`, `ref-md-repo-mindoktor-testing`      |
+| verb (for `tool-`)                | An action a developer invokes                               | `tool-md-commit`, `tool-md-create-task`, `tool-md-handle-cve` |
+
+The set is extensible — add a domain when a genuinely new knowledge area appears, keeping language tokens short (`js`, `go`, `py`). The authoritative list the validator enforces is `ALLOWED_DOMAINS` in `ref-md-agents-shareable-skills`'s `scripts/validateSharing.mts` (the domain token is portability metadata); keep this table in sync with it.
+
+**Choosing the domain:**
+
+- A language or framework convention → its short token (`js`, `go`, `py`, `css`, …)
+- Databases → `db`; data handling/privacy → `data`; models / LLM / NLP / ML → `ai`
+- An API surface → `api`; CI / deploy / infrastructure → `infra`
+- A cross-cutting engineering practice (developer-facing) → `dev`; a business / cross-department process → `biz`
+- The agent/skills system itself → `agents`; one specific repository → `repo` + the repo's short name
+- A `tool-` workflow → the action verb (`commit`, `handle`, `create`, `maintain`)
+
+For the full decision logic — the two tests, the tie-breakers (`data` vs `ai`, `db` vs `data`, `dev` vs `biz`, …), why "concerns" like docs/testing/git are **not** domains, and realistic per-domain examples — see [`references/choosing-a-domain.md`](references/choosing-a-domain.md).
+
+`dev` vs `biz` is an **audience** split: `dev` is developer-only (git, code, CI); `biz` is the cross-department/business process.
+
+### Shareability metadata
+
+Visibility — how far a skill may travel — and the rest of a skill's metadata live in frontmatter under `shareable-skills.`. `ref-md-agents-shareable-skills` is canonical (full param reference); the summary:
+
+```yaml
+metadata:
+  shareable-skills.owner-prefix: "md"              # name token / namespace; mirrors the name
+  shareable-skills.owner: "mindoktor/agentic-tools" # canonical home repo
+  shareable-skills.domain: "agents"                # knowledge area; mirrors the name (for ref-)
+  shareable-skills.visibility: "organization"      # repo-local | organization | public
+  shareable-skills.requires: "ref-md-agents-skills-authoring"  # hard deps — linked with the skill
+  shareable-skills.suggests: "ref-md-repo-dev-tools"           # soft deps — linked only on request
+  shareable-skills.reason: "encodes mindoktor service structure"    # when surprising
+```
+
+Key meanings, one line each:
+
+- `owner-prefix` / `owner` / `domain` — identity: the name's owner token, the canonical home repo, and the knowledge area.
+- `visibility` — how far the skill may travel: `repo-local` (one repo) / `organization` / `public`.
+- `requires` — hard deps, linked with the skill; `suggests` — soft deps, linked only on request.
+- `reason` — why a surprising visibility or dependency was chosen.
+
+The full rules — the visibility tiers, requires/suggests semantics, the narrower-visibility prohibition,
+and the flat-string constraint — live in `ref-md-agents-shareable-skills`.
+
+**Upstream / lineage.** The `agentic-tools` repo's spiritual upstream is [swiftpostlabs/agentic-tools](https://github.com/swiftpostlabs/agentic-tools) (the `sp-` owner prefix, a `.agents/skills/` layout). Full lineage and divergence notes live in `ref-md-agents-shareable-skills`.
+
+### Common mistakes
+
+| Mistake                                                  | Why it's wrong                                                        | Fix                                                                                  |
+| -------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Unprefixed skill (`architecture`, `coding-patterns`)     | Agents cannot distinguish action from reference                       | Add `ref-` (it's read-only knowledge) or `tool-` (it's a workflow)                   |
+| `ref-` skill with a procedure section                    | Reference skills don't orchestrate                                    | Extract the procedure into a `tool-` skill                                           |
+| `tool-` skill named with a noun (`tool-deployment`)      | Tool names need an action verb                                        | Rename to `tool-deploy` or `tool-run-deployment`                                     |
+| Vague name (`tool-helper`, `ref-utils`)                  | Poor discoverability, overlaps with everything                        | Name the specific action or domain                                                   |
+| Visibility token in the name (`ref-pub-x`, `tool-org-x`) | Visibility is mutable; encoding it forces renames and breaks symlinks | Use the owner prefix in the name; record visibility in `shareable-skills.visibility` |
+
+## SKILL.md Anatomy
+
+A well-structured dispatcher draws from these sections — include only those that add value for the specific skill. Simple linear skills may only need a title, routing table, and rules:
+
+1. **Title** — `# Skill Name` (optionally `— project-name` for project skills)
+2. **Purpose / intro** — one-sentence summary
+3. **Prerequisites** — skills, tools, or setup required before use
+4. **Routing table** — maps tasks to reference files
+5. **Tech stack** — framework, language, key tools (project skills only)
+6. **When to use** — bullet list of trigger conditions
+7. **Scope** — what the skill covers and what goes elsewhere (with links). Include it **whenever the skill borders or overlaps another** (clustered skills like `ref-md-js-*`, or the `dev`/`biz`/`coding-patterns` trio) so the boundary stays explicit and doesn't erode. A standalone skill with no neighbor can rely on the description's `Covers …`.
+8. **Rules / Instructions** — concise, actionable guidance
+9. **Related skills** — table linking to companion skills
+
+## Adapting Copied Skills
+
+When a skill is copied from another project:
+
+- Replace commands, packages, file paths, and framework references with the target repo's real stack.
+- Remove stale references to the source project's conventions.
+- If the skill is project-specific, make that explicit in the wording.
+
+## Cross-Platform Parity
+
+Keep effective guidance consistent across provider entry files:
+
+| File                                                        | Role                                       |
+| ----------------------------------------------------------- | ------------------------------------------ |
+| `AGENTS.md` (or a legacy `.github/copilot-instructions.md`) | Source of truth                            |
+| `GEMINI.md`                                                 | Thin stub — reads the source-of-truth file |
+| `CLAUDE.md`                                                 | Thin stub — reads the source-of-truth file |
+
+The default source of truth is a root `AGENTS.md`, read natively by most agents; a mature `.github/copilot-instructions.md` remains the source of truth in Copilot-centric repos that have not migrated. For the full model see `ref-md-agents-instructions-authoring`. Provider stubs are created per-repo as needed — a repo only carries the stubs for the providers actually used there (a repo where nobody runs Gemini has `CLAUDE.md` but no `GEMINI.md`).
+
+Only add provider-specific text when there is a real platform-specific need.
+
+## Markdown Conventions
+
+- **Tables**: use aligned style — pipe characters line up across all rows.
+- **Fenced code blocks**: always specify a language identifier (` ```json `, ` ```bash `, ` ```text `).
+- **Spacing**: one blank line before and after every code block and list.
+- **Keep `SKILL.md` concise**: move long checklists, templates, or examples into `references/`.
+
+### JavaScript / TypeScript Script Conventions
+
+- Script filenames should use **camelCase** in JS/TS contexts (for example, `validateSkills.mts`, not `validate_skills.mts`).
+- Use **`.mts`** (or `.mjs`) for runnable scripts so they are treated as ES modules without requiring `"type": "module"` in `package.json`. Prefer `.mts` over `.ts` for standalone scripts.
+- Prefer modern **ES module imports** (`import ... from ...`) over `require(...)` in TypeScript scripts.
+
+### Markdownlint Gotchas
+
+- **MD032**: a list that follows a paragraph needs a blank line before it — even when the paragraph ends with a colon.
+- **Table alignment** (project convention): every row in an aligned table must have pipe characters at the exact same column positions. Do not eyeball — run `node .claude/skills/ref-md-agents-skills-authoring/scripts/alignTables.mts <file> --write` to fix a file, or `--check` to verify one. `validateSkills.mts` enforces this, so a misaligned table fails validation.
+- **MD024**: heading text must be unique across the entire file. Under repeated parent sections, prefix the heading: `### Reasoning Patterns`, not `### Patterns`.
+- **MD033**: angle-bracket text like `<Event>` or `<module>` is interpreted as inline HTML. Wrap in backticks: `` `<Event>` ``.
+
+## Writing Effective Descriptions
+
+The `description` carries the entire burden of triggering. If it does not convey when the skill is useful, the agent will not activate it.
+
+- **Imperative phrasing**: "Use this skill when…" not "This skill does…"
+- **Focus on user intent**: describe what the user is trying to achieve, not the skill's internals.
+- **Be pushy**: list contexts where the skill applies, including cases the user might not name explicitly.
+- **Keep it concise**: a few sentences to a short paragraph. Hard limit: 1024 chars.
+
+For **tool skills**, make the description action-led: start with the action the skill performs, then say what knowledge or workflow it loads into the agent to perform that action correctly.
+
+For **ref skills**, an action-verb opener is **not** required — a noun phrase naming the domain ("Tracking conventions for mindoktor-app.", "Redux legacy patterns for …") is a perfectly good opener, since the skill *is* the knowledge rather than an action. The "Use when:" triggers and "Covers …" tail still carry the triggering burden either way.
+
+## Spending Context Wisely
+
+Every token in a skill competes for the agent's attention. Focus on what the agent would get wrong without the skill.
+
+- **Add what the agent lacks, omit what it knows** — no need to explain standard concepts.
+- **Design coherent units** — not too narrow (forces multi-skill loading) or too broad (hard to activate precisely).
+- **Moderate detail** — concise stepwise guidance with a working example beats exhaustive documentation.
+- **Provide defaults, not menus** — pick a default tool, mention alternatives briefly.
+- **Favor procedures over declarations** — teach *how to approach a class of problems*, not what to produce for a specific instance.
+- **Use the 3 Ws** — structure every rule or step as **What** (the action), **Why** (the rationale), **When** (the trigger condition). See below.
+
+## The 3 Ws Framework
+
+Every instruction in a skill should answer three questions: **What** to do, **Why** it matters, and **When** (in which situations) it applies. This replaces vague rules like "handle errors appropriately" with contextual guidance the agent can reason about.
+
+For **standalone rules**, use a table:
+
+```markdown
+| What                         | Why                                        | When                               |
+| ---------------------------- | ------------------------------------------ | ---------------------------------- |
+| Use parameterized queries    | String interpolation creates SQL injection | Any database query with user input |
+| Pin dependency versions      | Unpinned deps break reproducibility        | Adding or updating a dependency    |
+| Run the linter before commit | Catches style issues early                 | Every commit, no exceptions        |
+```
+
+For **multi-step workflows**, add a sequence column:
+
+```markdown
+| Step | What                      | Why                                      | When                            |
+| ---- | ------------------------- | ---------------------------------------- | ------------------------------- |
+| 1    | Back up the database      | Enables rollback if migration fails      | Before any schema change        |
+| 2    | Run schema migration      | Adds new columns without data loss       | After backup is verified        |
+| 3    | Backfill data             | Populates new columns from legacy fields | After schema migration succeeds |
+| 4    | Validate with spot checks | Confirms data integrity before cleanup   | After backfill completes        |
+| 5    | Drop legacy columns       | Removes technical debt                   | After validation passes         |
+```
+
+This format works because it activates agent reasoning (the *Why* gives purpose), perception (the *When* narrows scope), and planning (the step sequence defines order). See [`references/best-practices.md`](references/best-practices.md) for more examples.
+
+## Key Patterns for Instructions
+
+See [`references/best-practices.md`](references/best-practices.md) for full examples. Summary:
+
+| Pattern                 | When to use                                                           |
+| ----------------------- | --------------------------------------------------------------------- |
+| Gotchas section         | Non-obvious facts that defy the agent's assumptions                   |
+| Output template         | When output must match a specific format                              |
+| Checklist               | Multi-step workflows with dependencies or validation gates            |
+| Validation loop         | Agent must verify its own work before proceeding                      |
+| Plan-validate-execute   | Batch or destructive operations                                       |
+| Bundled scripts         | Agent reinvents the same logic across runs                            |
+| Load-skill precondition | A stack area has a matching `ref-md-*` skill the agent keeps skipping |
+
+### Load-skill precondition
+
+A `description:` trigger is advisory — the agent still *decides* whether the skill fits. For a self-contained feature ("add a tooltip"), an agent often judges the stack conventions irrelevant and writes the code without loading them, then drifts from rules the skill already documents. Description tuning does not fix this when the trigger already matches (it usually does); the miss is the agent's relevance judgment, not the phrasing.
+
+A consumer repo can close the gap by promoting its instruction-index skill table from advisory to a **precondition**: *before writing code in a stack area, load the matching `ref-md-*` skill(s).* Wire it per path in the repo's own `AGENTS.md` / instruction index (e.g. `CLINIC_APP/**` → React / TanStack Query / MUI / coding-patterns), and, once loaded, apply the precedence rule from `ref-md-dev-coding-patterns` — documented convention beats local imitation (imitate a neighbor only when it already conforms to the skill). A stronger, opt-in enforcement — a pre-write hook that fires the same path → skill map — is documented in `ref-md-agents-hooks`; it is the highest-guarantee, highest-noise option, so weigh it against review being the current safety net.
+
+## Evaluating Skills with Evals
+
+Run structured evaluations to verify a skill works reliably across varied prompts. See [`references/evaluating-skills.md`](references/evaluating-skills.md) for the full workflow. Summary:
+
+1. **Design test cases** — 2-3 realistic prompts with expected outputs, stored in `evals/evals.json`.
+2. **Run with and without the skill** — each test case runs twice for comparison.
+3. **Write assertions** — verifiable statements about the output (not "output is good").
+4. **Grade** — PASS/FAIL with specific evidence from the output.
+5. **Iterate** — generalize from failures, keep the skill lean, explain the why. Stop when feedback is consistently empty.
+
+## Eliciting Agent Capabilities
+
+Skills can deliberately activate specific cognitive modes — reasoning, memory, planning, perception, validation, communication, and tool calling. See the "Combining Agent Components" section in [`references/best-practices.md`](references/best-practices.md) for the pattern.
+
+## Skills Directories
+
+Skills live in a `.claude/skills/` directory under some root:
+
+| Directory | Path                     | Holds                                                 |
+| --------- | ------------------------ | ----------------------------------------------------- |
+| Global    | `~/.claude/skills/`      | User-wide skills an agent reads across every repo.    |
+| Project   | `<repo>/.claude/skills/` | Skills owned by, or linked into, a single repository. |
+
+Call the user-wide one **global**, never "home" — "home instructions" is a separate thing (the `~/.copilot/instructions/` index below). Both directories share the same `.claude/skills` segment, so tooling should build every skills path from one segment constant rather than repeating the literal.
+
+To create or remove these symlinks, use the `agentic-tools` repo's **`agentic-tools skills`** CLI (`link` / `unlink` / `prune`) — never hand-rolled `ln -s`. It resolves dependencies and refuses to link `repo-local` skills outward. See `ref-md-agents-shareable-skills` → The linking CLI for the commands.
+
+## Registration
+
+After creating a skill, register it so agents can discover it:
+
+| Scope   | Where to register                                               |
+| ------- | --------------------------------------------------------------- |
+| Project | `AGENTS.md` (or `.github/copilot-instructions.md`) Skills table |
+| Global  | `~/.copilot/instructions/default.instructions.md` Skills table  |
+
+## Validation
+
+Use the [`skills-ref`](https://github.com/agentskills/agentskills/tree/main/skills-ref) reference library to validate a skill's frontmatter and naming conventions:
+
+```bash
+skills-ref validate ./my-skill
+```
+
+In the `agentic-tools` repo (where skills are authored) — or in any consumer repo that vendors these validators (they ship inside the vendored skill, so a repo's own CI runs them from `.claude/skills/…`, no `agentic-tools` checkout required) — also run the two local validators. `validateSkills.mts` (in this skill) covers authoring and structure — naming, frontmatter essentials, line budget, broken local links, and markdown table alignment:
+
+```bash
+node .claude/skills/ref-md-agents-skills-authoring/scripts/validateSkills.mts
+```
+
+`validateSharing.mts` (in `ref-md-agents-shareable-skills`) covers the portability metadata — owner-prefix/owner/domain/visibility and the dependency graph (targets exist and are equal-or-wider visibility):
+
+```bash
+node .claude/skills/ref-md-agents-shareable-skills/scripts/validateSharing.mts
+```
+
+Modern Node runs `.mts` files directly, so no `ts-node` setup is required.
+
+Recommended order:
+
+1. Run both local validators (`validateSkills.mts` + `validateSharing.mts`) for broad repo-level checks.
+2. Run `skills-ref validate` for spec-focused validation.
+3. Run markdown diagnostics and resolve remaining issues.
+
+## Related Skills
+
+| Skill                     | When to load                                        |
+| ------------------------- | --------------------------------------------------- |
+| `tool-md-maintain-skills` | Auditing, reorganizing, or updating existing skills |

--- a/.claude/skills/ref-md-agents-skills-authoring/assets/template.md
+++ b/.claude/skills/ref-md-agents-skills-authoring/assets/template.md
@@ -1,0 +1,88 @@
+# Skill Starter Template
+
+Use this template when creating a new skill. Adapt it to the real repo before keeping it.
+
+````markdown
+---
+name: my-skill
+description: >-
+  Brief description (action-led for tool- skills; a domain noun phrase is fine for ref- skills).
+  Use when: trigger condition 1, trigger condition 2.
+  Covers topic A, topic B.
+metadata:
+  author: mindoktor
+  version: "1.0"
+  shareable-skills.owner-prefix: "md"                  # name token; mirrors the name
+  shareable-skills.owner: "mindoktor/agentic-tools"    # canonical home repo
+  shareable-skills.domain: "agents"                    # knowledge area; mirrors the name (for ref-)
+  shareable-skills.visibility: "organization"          # repo-local | organization | public
+  # shareable-skills.requires: "ref-md-other-skill"    # hard deps (comma-separated), if any
+  # shareable-skills.suggests: "ref-md-neighbor-skill" # soft deps (comma-separated), if any
+  # shareable-skills.reason: "why a surprising visibility or dependency" # optional, when non-obvious
+  # Provenance (vendored-sha / vendored-time, or forked-from) is NOT authored here — the
+  # vendoring/fork workflow stamps it onto a COPY; never set it on an original. See tool-md-vendor-skill.
+---
+
+# Skill Title
+
+## Purpose
+
+One-sentence description of what this skill enforces or enables.
+
+## Prerequisites
+
+- Required skills, tools, or setup the agent needs before using this skill.
+- Remove this section if there are no prerequisites.
+
+## When to Use This Skill
+
+- Trigger condition 1.
+- Trigger condition 2.
+
+## Scope
+
+This skill covers X. It does not cover Y or Z.
+Remove this section if scope is obvious from the description.
+
+## Routing Table
+
+| Task                  | Read                                                |
+|-----------------------|-----------------------------------------------------|
+| Short task descriptor | [`references/filename.md`](references/filename.md)  |
+
+## Rules
+
+Use the 3 Ws (What / Why / When) to structure each rule:
+
+| What                      | Why                                    | When                               |
+|---------------------------|----------------------------------------|------------------------------------|
+| Action the agent must take | Business or technical rationale       | Situation that triggers this rule  |
+
+For multi-step workflows, add a Step column:
+
+| Step | What        | Why                  | When                    |
+|------|-------------|----------------------|-------------------------|
+| 1    | First action | Reason it comes first | Trigger for this step  |
+| 2    | Next action  | Reason it follows    | After step 1 succeeds  |
+
+## Examples
+
+```text
+Concrete example showing the expected output or structure.
+```
+
+## Related Skills
+
+| Skill                        | When to load           |
+|------------------------------|------------------------|
+| `other-skill`                | Brief trigger          |
+````
+
+## Adaptation Reminders
+
+- Replace all placeholder names, commands, and file paths with the real repo's values.
+- Set `shareable-skills.owner-prefix` and `shareable-skills.domain` to match the skill's name, and choose a `visibility` (`repo-local` / `organization` / `public`). Uncomment `requires` / `suggests` / `reason` only as needed. Leave the provenance fields alone — they belong to the vendoring workflow, not to authoring an original skill.
+- If this is a tool skill, rename it to `tool-md-<verb>[-<target>]` and make both the title and description action-led.
+- Remove sections that add no value for this skill's responsibility.
+- Move bulky examples, checklists, or reference docs into `references/`. Move output format templates and scaffolds into `assets/`.
+- If the skill is repo-specific, make that explicit in the name.

--- a/.claude/skills/ref-md-agents-skills-authoring/evals/evals.json
+++ b/.claude/skills/ref-md-agents-skills-authoring/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "ref-md-agents-skills-authoring",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Create a new project skill called tool-md-deploy that helps deploy services to production. It should cover pre-deploy checks, deployment steps, and rollback procedures. Put it in .claude/skills/tool-md-deploy/.",
+      "expected_output": "A SKILL.md with valid YAML frontmatter (name: tool-md-deploy, description with 'Use when:' and 'Covers'), a routing table pointing to reference files, kebab-case folder name, and the tool- prefix since it's an action skill.",
+      "assertions": [
+        "SKILL.md has YAML frontmatter with name: tool-md-deploy",
+        "description uses imperative phrasing and includes 'Use when:' triggers",
+        "description is under 1024 characters",
+        "name in frontmatter matches the folder name (tool-md-deploy)",
+        "File contains a routing table mapping tasks to reference files",
+        "Reference files use relative paths (./references/ or references/)",
+        "Folder name uses kebab-case",
+        "Skill uses tool- prefix because it orchestrates a deployment action"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "I have a skill called helpers that crams our TypeScript conventions, React patterns, and testing guidelines all into one SKILL.md. Review it and tell me what's wrong.",
+      "expected_output": "Identifies that the skill violates one-responsibility-per-skill by mixing unrelated concerns, has a vague unprefixed name, and should be split into separate skills (e.g., ref-md-js-typescript, ref-md-js-react, ref-md-js-tests). Should recommend moving detailed content to references/ and keeping SKILL.md as a dispatcher.",
+      "files": ["evals/files/bloated-skill.md"],
+      "assertions": [
+        "Identifies that the skill mixes multiple unrelated responsibilities in one SKILL.md",
+        "Recommends splitting into multiple skills, one per concern",
+        "Suggests moving detailed content to references/ subdirectory",
+        "Recommends ref- prefix since these are convention/knowledge skills, not action workflows",
+        "Does NOT suggest tool- prefix for pure convention documentation"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Write a skill for our team's Jira workflow conventions — how we name tickets, what fields are required, how we transition statuses. This is just documentation for the agent to follow, developers won't invoke it directly.",
+      "expected_output": "A skill with ref- prefix (e.g., ref-md-biz-jira-conventions), valid frontmatter, concise SKILL.md dispatcher routing to reference files for each topic area. Should NOT use tool- prefix since the user explicitly said it's background documentation, not a dev-invoked action.",
+      "assertions": [
+        "Skill uses ref- prefix, not tool-",
+        "SKILL.md has valid YAML frontmatter with name matching folder",
+        "Description explains this is reference material for agent consumption",
+        "Content is organized with a routing table, not a monolithic doc",
+        "Does not orchestrate any multi-step workflow or action"
+      ]
+    }
+  ]
+}

--- a/.claude/skills/ref-md-agents-skills-authoring/evals/files/bloated-skill.md
+++ b/.claude/skills/ref-md-agents-skills-authoring/evals/files/bloated-skill.md
@@ -1,0 +1,200 @@
+---
+name: helpers
+description: All our coding conventions and patterns.
+---
+
+# Helpers
+
+This skill covers everything about how we write code.
+
+## TypeScript Conventions
+
+### Naming
+
+- Use PascalCase for types and interfaces
+- Use camelCase for variables and functions
+- Use SCREAMING_SNAKE_CASE for constants
+- Prefix interfaces with I only when there's a naming collision with a class
+- Use descriptive names, avoid abbreviations except for universally understood ones (id, err, ctx, req, res)
+
+### Type Safety
+
+- Prefer `unknown` over `any`
+- Use `as const` for literal objects that shouldn't change
+- Avoid type assertions (`as`) — use type guards instead
+- Use discriminated unions for state machines
+- Always type function return values for public APIs
+
+### Error Handling
+
+- Use custom error classes that extend Error
+- Always set the cause property when wrapping errors
+- Never catch and ignore errors silently
+- Use Result<T, E> pattern for expected failures
+- Reserve try/catch for unexpected failures
+
+### Imports
+
+- Use named imports over default imports
+- Sort imports: built-in → external → internal → relative
+- Use path aliases configured in tsconfig
+- Never use require() in TypeScript files
+
+### Generics
+
+- Use meaningful generic names: TItem, TResponse, not T, U
+- Constrain generics when possible: <T extends Record<string, unknown>>
+- Avoid deeply nested generics (max 2 levels)
+- Document complex generic types with JSDoc
+
+### Async Patterns
+
+- Prefer async/await over .then() chains
+- Use Promise.all() for independent concurrent operations
+- Use Promise.allSettled() when you need all results regardless of failures
+- Never use new Promise() when async/await works
+- Always handle promise rejections
+
+### String Handling
+
+- Use template literals over string concatenation
+- Use tagged templates for SQL, HTML, or other structured strings
+- Prefer String.prototype methods over regex for simple operations
+- Use Intl APIs for locale-aware formatting
+
+### Collections
+
+- Prefer Map over plain objects for dynamic keys
+- Use Set for unique value collections
+- Prefer Array methods (map, filter, reduce) over for loops
+- Use for...of over for...in for arrays
+- Avoid mutating arrays — use spread or Array.from()
+
+### Module Patterns
+
+- One public export per file for components
+- Use barrel files (index.ts) sparingly — only for public API boundaries
+- Keep files under 300 lines
+- Split large modules by concern, not by type
+
+## React Patterns
+
+### Component Structure
+
+- Use function components exclusively
+- Prefer named exports over default exports
+- Co-locate component, styles, types, and tests
+- Order: types → hooks → helpers → component → exports
+
+### Hooks
+
+- Custom hooks must start with "use"
+- Extract complex state logic into custom hooks
+- Keep hook dependencies minimal
+- Avoid useEffect for derived state — use useMemo instead
+- Never call hooks conditionally
+
+### State Management
+
+- Prefer local state over global state
+- Use context for theme, auth, locale — not for all shared state
+- Keep state as close to where it's used as possible
+- Normalize complex nested state
+- Use reducers for state with complex transitions
+
+### Props
+
+- Destructure props in the function signature
+- Use interface for prop types, not type alias
+- Mark optional props with ? — don't use defaultProps
+- Avoid spreading all props onto DOM elements
+- Limit props to 5-7 per component — split if more
+
+### Rendering
+
+- Avoid inline object/array creation in JSX — extract to constants or useMemo
+- Use Fragment (<>) instead of wrapping divs
+- Conditional rendering: ternary for simple, early return for complex
+- Extract repeated JSX into sub-components
+- Avoid nested ternaries in JSX
+
+### Event Handlers
+
+- Name handlers `handle<Event>`: handleClick, handleSubmit
+- Use useCallback for handlers passed to child components
+- Avoid inline arrow functions in JSX for frequently re-rendered components
+- Always prevent default for form submissions
+
+### Performance
+
+- Memoize expensive computations with useMemo
+- Wrap child components with React.memo when parent re-renders frequently
+- Use virtualization for long lists (react-window or react-virtuoso)
+- Lazy load routes and heavy components with React.lazy
+- Profile before optimizing — don't guess
+
+### Styling
+
+- Use CSS Modules for component-scoped styles
+- Use design tokens from the theme for colors, spacing, typography
+- Avoid inline styles except for dynamic values
+- Mobile-first responsive design
+- Use logical properties (margin-inline, padding-block) for RTL support
+
+### Forms
+
+- Use react-hook-form for form state management
+- Validate with zod schemas
+- Show validation errors inline, below the field
+- Disable submit button while submitting
+- Reset form state after successful submission
+
+### Accessibility
+
+- All interactive elements must be keyboard accessible
+- Use semantic HTML elements (button, nav, main, article)
+- Add aria-label to icon-only buttons
+- Manage focus when opening/closing modals and drawers
+- Test with screen reader at least once per feature
+
+## Testing Guidelines
+
+### Unit Tests
+
+- Test behavior, not implementation
+- Use describe/it blocks with readable descriptions
+- Arrange-Act-Assert pattern
+- One assertion per test when possible
+- Mock external dependencies, not internal modules
+
+### Component Tests
+
+- Use React Testing Library
+- Query by role, label, or text — avoid test IDs
+- Test user interactions, not component internals
+- Render with necessary providers (theme, router, etc.)
+- Avoid snapshot tests — they're too brittle
+
+### Integration Tests
+
+- Test full user flows through the component tree
+- Use MSW for API mocking
+- Test error states and loading states
+- Verify accessibility in integration tests
+- Keep integration tests focused — max 10 assertions
+
+### Test Organization
+
+- Co-locate test files with source: Button.test.tsx next to Button.tsx
+- Use fixtures/ for shared test data
+- Use factories for creating test objects
+- Shared test utilities go in test/utils/
+- Name test files consistently: `<module>.test.ts`
+
+### Mocking
+
+- Prefer dependency injection over jest.mock
+- Mock at the boundary (API, filesystem, clock)
+- Reset mocks between tests with afterEach
+- Type your mocks — avoid any in test code
+- Use jest.spyOn for observing calls without changing behavior

--- a/.claude/skills/ref-md-agents-skills-authoring/references/best-practices.md
+++ b/.claude/skills/ref-md-agents-skills-authoring/references/best-practices.md
@@ -1,0 +1,332 @@
+# Best Practices for Skill Authoring
+
+## Main References
+
+- <https://agentskills.io/skill-creation/best-practices> — writing well-scoped and calibrated skills.
+- <https://agentskills.io/skill-creation/optimizing-descriptions> — testing and improving description triggering.
+- <https://agentskills.io/skill-creation/evaluating-skills> — eval-driven iteration for skill quality.
+- <https://agentskills.io/skill-creation/using-scripts> — bundling executable scripts in skills.
+- <https://agentskills.io/specification> — the complete `SKILL.md` format reference.
+
+## Start from Real Expertise
+
+Generic skills written without domain context produce vague guidance ("handle errors appropriately"). Effective skills are grounded in:
+
+- **Hands-on extraction**: complete a real task with an agent, then extract the reusable pattern — steps that worked, corrections you made, input/output formats, and context you provided.
+- **Existing artifacts**: synthesize from internal docs, runbooks, API specs, code review comments, version history, and real failure cases. Project-specific material always beats generic references.
+
+## Refine with Real Execution
+
+The first draft usually needs work. Run the skill against real tasks, then feed the results — all of them, not just failures — back into the creation process. Even a single pass of execute-then-revise noticeably improves quality.
+
+Read agent **execution traces**, not just final outputs. Common waste signals:
+
+- Instructions too vague (agent tries several approaches)
+- Instructions that do not apply to the current task (agent follows them anyway)
+- Too many options without a clear default
+
+## Spending Context Wisely
+
+Once activated, the full `SKILL.md` body loads alongside conversation history, system context, and other active skills. Every token competes for attention.
+
+### Add What the Agent Lacks
+
+Focus on project-specific conventions, domain-specific procedures, non-obvious edge cases, and the particular tools to use. If the agent would handle it correctly without the skill, cut it.
+
+Bad — agent already knows this:
+
+```markdown
+## Extract PDF text
+
+PDF (Portable Document Format) files are a common file format...
+```
+
+Good — jumps to what the agent would not know:
+
+```markdown
+## Extract PDF text
+
+Use pdfplumber for text extraction. For scanned documents,
+fall back to pdf2image with pytesseract.
+```
+
+### Design Coherent Units
+
+Scope a skill like you would scope a function: a coherent unit of work that composes well with other skills.
+
+- **Too narrow**: multiple skills must load for a single task, risking overhead and conflicts.
+- **Too broad**: hard to activate precisely and wastes context on irrelevant sections.
+
+A skill for "querying a database and formatting results" is one coherent unit. A skill that also covers database administration is trying to do too much.
+
+### Aim for Moderate Detail
+
+Overly comprehensive skills can hurt. Concise, stepwise guidance with a working example tends to outperform exhaustive documentation. When you find yourself covering every edge case, consider whether most are better handled by the agent's own judgment.
+
+### Don't Summarize an Exception-Bearing Rule in the Dispatcher
+
+A `SKILL.md` dispatcher routes to a `references/*.md` file for authoritative detail. When the dispatcher instead **summarizes a rule that has exceptions** — stating the general form while the exception lives only in the reference — an agent acting on the summary feels it has enough and **skips the pointer**. A half-stated rule with exceptions is *worse* than a bare pointer: the more complete the summary reads, the more it suppresses the follow-through to the file that holds the detail that actually changes the answer, and the failure is silent until the wrong output appears.
+
+Real failure (MDP-12002, 2026-07-08): a Quick Reference stated the git branch prefix as "your initials — see `git-workflow.md`". The reference carried a per-developer exception table (`Fabio Colella → fco`, because `fc` was taken). The agent acted on "your initials", produced `fc/…`, and the branch had to be renamed. The formula gave just enough to act and hid the one detail that mattered.
+
+The fix depends on whether the rule has exceptions:
+
+| Rule shape                                                        | Fix                                                                                                                                                                                                                                    | Why                                                                                                         |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Exception-bearing** (per-case table, overrides, "except when…") | **De-anticipate**: replace the formula with a pointer that *flags the hazard* — e.g. "branch prefix has **per-developer exceptions** — read `git-workflow.md` before naming a branch." State no value the agent could act on directly. | A pointer that signals "there's a catch here" makes skipping the reference feel unsafe, which is the point. |
+| **Stable / exceptionless**                                        | **Self-sufficient** is fine: state the rule in the dispatcher so acting on it alone is safe (a pointer is optional).                                                                                                                   | No hidden exception means no trap; duplication cost is the only downside.                                   |
+
+Rule of thumb: a dispatcher summary must be either **safe to act on alone** (exceptionless) or **clearly not actionable without the reference** (hazard-flagged). The dangerous middle is a summary that looks complete but isn't.
+
+### Examples in a shared skill: neutral or show-both
+
+When a skill is shared/vendored across repos and an example diverges between consumers (an import path, a token name, a key shape, a file layout), do **not** show one consumer's real value as the default — it misleads every other consumer, and swapping to the other repo's form just flips the victim. If the divergence is incidental to the lesson, use a **neutral placeholder** real in no consumer; if the divergence *is* the lesson, **show both, labeled** per consumer. Full rule and the false-neutral trap: `ref-md-agents-shareable-skills` → "Shared examples: neutral, or show-both".
+
+## The 3 Ws Framework — What, Why, When
+
+Every instruction the agent receives should answer three questions:
+
+- **What**: the concrete action to perform.
+- **Why**: the rationale — so the agent can reason about edge cases and adapt when context changes.
+- **When**: the trigger condition — so the agent knows which situations call for this action.
+
+This replaces flat rule lists ("do X") with contextual guidance the agent can reason about. It directly activates the reasoning component: an agent that understands *why* makes better decisions than one following rigid directives.
+
+### Flat rules → 3 Ws table
+
+Before — the agent knows *what* but not *why* or *when*:
+
+```markdown
+## Rules
+
+- Use parameterized queries.
+- Pin dependency versions.
+- Run the linter before committing.
+```
+
+After — the agent can reason about each rule in context:
+
+```markdown
+## Rules
+
+| What                          | Why                                        | When                                  |
+|-------------------------------|--------------------------------------------|---------------------------------------|
+| Use parameterized queries     | String interpolation creates SQL injection | Any database query with user input    |
+| Pin dependency versions       | Unpinned deps break reproducibility        | Adding or updating a dependency       |
+| Run the linter before commit  | Catches style issues early                 | Every commit, no exceptions           |
+```
+
+### Multi-step workflows → sequenced 3 Ws table
+
+When a task requires multiple steps, add a **Step** column. This gives the agent planning context (sequence + dependencies) alongside reasoning context (why + when):
+
+```markdown
+## Database migration workflow
+
+| Step | What                        | Why                                       | When                             |
+|------|-----------------------------|-------------------------------------------|----------------------------------|
+| 1    | Back up the database        | Enables rollback if migration fails       | Before any schema change         |
+| 2    | Run schema migration        | Adds new columns without data loss        | After backup is verified         |
+| 3    | Backfill data               | Populates new columns from legacy fields  | After schema migration succeeds  |
+| 4    | Validate with spot checks   | Confirms data integrity before cleanup    | After backfill completes         |
+| 5    | Drop legacy columns         | Removes technical debt                    | After validation passes          |
+```
+
+### When to use each format
+
+| Situation                                     | Format                         |
+| --------------------------------------------- | ------------------------------ |
+| Independent rules (no ordering)               | 3 Ws table (no Step column)    |
+| Ordered workflow with dependencies            | Sequenced 3 Ws table           |
+| Single fragile command (no flexibility)       | Prescriptive prose (see below) |
+| Flexible guidance (multiple valid approaches) | 3 Ws table with relaxed *What* |
+
+### Mixing 3 Ws with other patterns
+
+The 3 Ws framework composes well with gotchas, validation loops, and checklists:
+
+- **Gotchas** are essentially rows where *Why* explains a non-obvious failure mode and *When* is "always" or "whenever you touch X."
+- **Checklists** are sequenced 3 Ws tables with checkboxes in the *What* column.
+- **Validation loops** are sequenced tables where the last row is a conditional ("If validation fails, return to step N").
+
+## Calibrating Control
+
+Match the specificity of instructions to the fragility of the task.
+
+### Give freedom when multiple approaches are valid
+
+Use 3 Ws tables with a relaxed *What* column — describe the goal, not the exact command:
+
+```markdown
+## Code review process
+
+| What                                   | Why                                        | When                           |
+|----------------------------------------|--------------------------------------------|--------------------------------|
+| Check queries for SQL injection        | Parameterized queries prevent injection    | Any code touching the database |
+| Verify auth checks on endpoints        | Unauthenticated access is a security hole  | Every new or modified endpoint |
+| Look for race conditions               | Concurrent paths can corrupt shared state  | Code using shared resources    |
+| Confirm error messages are safe        | Leaked internals aid attackers             | Any user-facing error path     |
+```
+
+### Be prescriptive when operations are fragile
+
+Some operations have no flexibility. Use prose with an explicit prohibition:
+
+``````markdown
+## Database migration
+
+Run exactly this sequence:
+
+```bash
+python scripts/migrate.py --verify --backup
+```
+
+Do not modify the command or add additional flags.
+``````
+
+### Provide Defaults, Not Menus
+
+Pick a default and mention alternatives briefly:
+
+```markdown
+Use pdfplumber for text extraction.
+For scanned PDFs requiring OCR, use pdf2image with pytesseract instead.
+```
+
+### Favor Procedures over Declarations
+
+Teach *how to approach a class of problems*, not what to produce for a specific instance:
+
+```markdown
+| Step | What                                            | Why                                     | When                    |
+|------|-------------------------------------------------|-----------------------------------------|-------------------------|
+| 1    | Read schema from `references/schema.yaml`       | Identifies relevant tables and joins    | Start of any query task |
+| 2    | Join tables using `_id` foreign key convention   | Project convention, not always obvious  | Multi-table queries     |
+| 3    | Apply user's filters as WHERE clauses            | Translates natural language to SQL      | User specifies criteria |
+| 4    | Aggregate numeric columns, format as markdown    | Structured output is easier to consume  | Final output step       |
+```
+
+## Writing Skill Instructions
+
+How you phrase instructions matters as much as what they say.
+
+| What                                    | Why                                                                                                                                           | When                                                            |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Explain the *why* behind every rule     | Today's LLMs have good theory of mind -- a rule with reasoning is followed more reliably and adapted more intelligently than a bare directive | Always, but especially for constraints and quality requirements |
+| Prefer reasoning over rigid directives  | Heavy-handed ALL-CAPS MUSTs and strict templates cause brittle compliance -- reframe as "this matters because..."                             | When you catch yourself writing ALWAYS or NEVER                 |
+| Generalize from specific feedback       | Narrow patches ("add a comma after the title") overfit to one example and fail on the next                                                    | When iterating on eval results                                  |
+| Keep the skill lean                     | Extra instructions compete for attention and can cause the agent to waste effort following irrelevant guidance                                | After every iteration -- cut what isn't pulling its weight      |
+| Read execution traces, not just outputs | Traces reveal where the agent is confused, retrying, or following instructions that don't apply to the current task                           | When investigating why a skill underperforms                    |
+| Bundle repeated work into scripts       | If every run independently writes the same helper logic, that's wasted tokens and a reliability risk                                          | When you see the same boilerplate in 2+ execution traces        |
+
+## Key Instruction Patterns
+
+### Gotchas Sections
+
+The highest-value content: concrete corrections to mistakes the agent will make without being told. Keep in `SKILL.md` where the agent reads them before encountering the situation.
+
+```markdown
+## Gotchas
+
+- The `users` table uses soft deletes. Queries must include
+  `WHERE deleted_at IS NULL` or results will include deactivated accounts.
+- The user ID is `user_id` in the database, `uid` in the auth service,
+  and `accountId` in the billing API. All three refer to the same value.
+- The `/health` endpoint returns 200 even if the database is down.
+  Use `/ready` to check full service health.
+```
+
+When an agent makes a mistake you have to correct, add the correction to the gotchas section.
+
+### Output Templates
+
+More reliable than describing formats in prose. Short templates live inline in `SKILL.md`; longer ones go in `assets/` (not `references/` — templates are fill-in-the-blanks structures, not documentation).
+
+```markdown
+## Report structure
+
+Use this template, adapting sections as needed:
+
+# [Analysis Title]
+
+## Executive summary
+[One-paragraph overview of key findings]
+
+## Key findings
+- Finding 1 with supporting data
+- Finding 2 with supporting data
+
+## Recommendations
+1. Specific actionable recommendation
+2. Specific actionable recommendation
+```
+
+### Checklists for Multi-Step Workflows
+
+Explicit checklists help the agent track progress and avoid skipping steps:
+
+```markdown
+## Form processing workflow
+
+Progress:
+- [ ] Step 1: Analyze the form (run `scripts/analyze_form.py`)
+- [ ] Step 2: Create field mapping (edit `fields.json`)
+- [ ] Step 3: Validate mapping (run `scripts/validate_fields.py`)
+- [ ] Step 4: Fill the form (run `scripts/fill_form.py`)
+- [ ] Step 5: Verify output (run `scripts/verify_output.py`)
+```
+
+### Validation Loops
+
+Instruct the agent to validate its work before moving on:
+
+```markdown
+## Editing workflow
+
+1. Make your edits
+2. Run validation: `python scripts/validate.py output/`
+3. If validation fails:
+   - Review the error message
+   - Fix the issues
+   - Run validation again
+4. Only proceed when validation passes
+```
+
+### Plan-Validate-Execute
+
+For batch or destructive operations, create an intermediate plan, validate it, then execute:
+
+```markdown
+## PDF form filling
+
+1. Extract form fields: `python scripts/analyze_form.py input.pdf` → `form_fields.json`
+2. Create `field_values.json` mapping each field name to its intended value
+3. Validate: `python scripts/validate_fields.py form_fields.json field_values.json`
+4. If validation fails, revise `field_values.json` and re-validate
+5. Fill the form: `python scripts/fill_form.py input.pdf field_values.json output.pdf`
+```
+
+The key ingredient is the validation step that checks the plan against a source of truth.
+
+## Optimizing Descriptions
+
+See [`optimizing-descriptions.md`](optimizing-descriptions.md) for the full workflow including trigger eval queries, train/validation splits, the optimization loop, and applying results.
+
+## Evaluating Skill Quality
+
+See [`evaluating-skills.md`](evaluating-skills.md) for the full eval workflow including test cases, assertions, grading, and the iteration loop.
+
+## Using Scripts in Skills
+
+See [`using-scripts.md`](using-scripts.md) for one-off commands, self-contained scripts with inline dependencies, and script design guidelines for agentic use.
+
+## Combining Agent Components
+
+Real-world skills combine multiple cognitive modes. A good skill might:
+
+1. **Perceive**: read the project structure and identify the tech stack.
+2. **Plan**: decompose the task into phases with dependencies.
+3. **Reason**: apply chain-of-thought to choose the right approach.
+4. **Act**: invoke scripts and CLI tools to execute the plan.
+5. **Validate**: run tests and check output against expected results (learning loop).
+6. **Communicate**: format the result for the intended audience.

--- a/.claude/skills/ref-md-agents-skills-authoring/references/checklist.md
+++ b/.claude/skills/ref-md-agents-skills-authoring/references/checklist.md
@@ -1,0 +1,90 @@
+# Skill Authoring Checklist
+
+Use this checklist when creating, reviewing, or refactoring a skill.
+
+## Structure
+
+- [ ] Skill lives at `.claude/skills/<skill-name>/SKILL.md`
+- [ ] Folder name is kebab-case
+- [ ] `SKILL.md` stays concise — long content moved to `references/`, `assets/`, or `scripts/`
+- [ ] All subfile links use relative paths (`./references/...`)
+
+## Frontmatter
+
+- [ ] YAML frontmatter includes `name` and `description`
+- [ ] `name` field matches the folder name exactly
+- [ ] `name` is 1–64 chars, lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens
+- [ ] `description` is 1–1024 chars, includes "Use when:" triggers and "Covers ..." topics
+- [ ] `description` uses imperative phrasing and focuses on user intent
+- [ ] `metadata` block present (recommended, not required)
+- [ ] `metadata.author` is `mindoktor` unless the user explicitly requested a different owner
+- [ ] If this is a tool skill, the name follows `tool-md-<verb>[-<target>]`
+- [ ] If this is a tool skill, the description starts with the action and explains what knowledge or workflow it loads into the agent
+
+## Content
+
+- [ ] Skill has one clear responsibility — not mixing unrelated domains
+- [ ] Includes a "When to use" section or equivalent trigger list
+- [ ] Guidance uses the target repo's actual commands, file paths, and packages
+- [ ] No stale references from a source project were preserved
+- [ ] Concrete examples or file structures provided to reduce ambiguity
+- [ ] Values stated explicitly, not left implicit
+- [ ] Adds only what the agent would get wrong without the skill
+- [ ] Provides defaults, not menus — alternatives mentioned briefly
+- [ ] Favors procedures over declarations — teaches approach, not specific output
+- [ ] Explains the "why" for critical rules (reasoning > rigid directives)
+- [ ] Rules and steps use the 3 Ws format (What / Why / When) where applicable
+
+## Agent Capabilities
+
+Check the items that apply to this skill's domain. Not every skill needs all seven:
+
+- [ ] Reasoning: includes chain-of-thought steps or self-reflection checkpoints where decisions matter
+- [ ] Memory: gotchas capture past failures; reference files serve as structured knowledge
+- [ ] Planning: complex tasks are decomposed into phases with dependencies
+- [ ] Perception: input formats and context-gathering steps are declared
+- [ ] Learning: validation loops let the agent check and correct its own work
+- [ ] Communication: output format templates match the audience
+- [ ] Tool calling: scripts are listed, invocation patterns are clear, output is structured
+
+## Progressive Disclosure
+
+- [ ] `SKILL.md` is under 500 lines / 5000 tokens
+- [ ] Detailed reference material lives in `references/` or `assets/`
+- [ ] Reference file loading is conditional ("Read X if Y happens"), not blanket
+- [ ] The dispatcher does not summarize an **exception-bearing** rule as a complete formula (which suppresses reading the reference) — it either states an exceptionless rule in full or flags the hazard and points on (see `best-practices.md` → "Don't Summarize an Exception-Bearing Rule in the Dispatcher")
+
+## Formatting
+
+- [ ] Tables use aligned style — pipes line up across all rows (verify with character count, not eyeballing)
+- [ ] Fenced code blocks have a language identifier
+- [ ] Blank lines surround every code block and list (MD032)
+- [ ] Heading text is unique across the file — prefix with context if needed (MD024)
+- [ ] Angle-bracket text like `<Event>` is wrapped in backticks (MD033)
+- [ ] Workflow labels are concrete and operational (not vague)
+- [ ] Run markdownlint and fix all warnings before finalizing
+
+## Provider Agnosticism
+
+- [ ] No provider-specific assumptions unless a real exception exists
+- [ ] If provider files are referenced, the reference-first pattern is preserved
+- [ ] Effective guidance is consistent across Copilot, Gemini, and Claude
+
+## Registration
+
+- [ ] Skill registered in the appropriate instructions file (project or home)
+
+## Automation Gates
+
+- [ ] Run `node .claude/skills/ref-md-agents-skills-authoring/scripts/validateSkills.mts` and ensure it passes.
+- [ ] Run `skills-ref validate ./my-skill` (or the actual skill path) when available.
+- [ ] Re-run markdown diagnostics and clear all reported issues.
+- [ ] If the validator reports broken links, fix link paths before final review.
+
+## Naming
+
+- [ ] Every skill uses either `tool-` or `ref-` prefix — no unprefixed skills
+- [ ] `tool-` skills use `tool-md-<verb>[-<target>]` with a concrete action verb — they guide multi-step workflows
+- [ ] `ref-` skills use `ref-md-<domain>[-<topic>]` naming the knowledge domain — they provide read-only knowledge, not workflows
+- [ ] No `ref-` skill contains a procedure/workflow section (extract to a `tool-` skill if it does)
+- [ ] No `tool-` skill is named with a noun instead of a verb

--- a/.claude/skills/ref-md-agents-skills-authoring/references/choosing-a-domain.md
+++ b/.claude/skills/ref-md-agents-skills-authoring/references/choosing-a-domain.md
@@ -1,0 +1,61 @@
+# Choosing a Skill's Domain
+
+Decision guide for the `<domain>` slot in a skill name. Load this when creating or reclassifying a skill and the domain is not obvious. The authoritative allow-list is `ALLOWED_DOMAINS` in `ref-md-agents-shareable-skills`'s `scripts/validateSharing.mts`; the quick-reference table is in [`../SKILL.md`](../SKILL.md).
+
+## First: `ref-` or `tool-`?
+
+- `tool-` — a step-by-step action a developer invokes. Name it by the **verb** (`commit`, `create`, `handle`, `maintain`, `test`, …). It does **not** take a domain.
+- `ref-` — read-only knowledge or conventions. Pick a **domain** below.
+
+## The domains
+
+| Domain                            | What it is                                                                  | Realistic examples                                                               |
+| --------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `js` · `go` · `py` · `rb` · `css` | One short token per language or framework                                   | `ref-md-js-react`, `ref-md-go-error-handling`, `ref-md-rb-cve`, `ref-md-css-…`   |
+| `db`                              | Databases, schemas, migrations                                              | `ref-md-db-migrations`, `ref-md-db-indexing`                                     |
+| `data`                            | The data itself — privacy/anonymization, pipelines, quality, labeling       | `ref-md-data-anonymization`, `ref-md-data-pii-handling`, `ref-md-data-pipelines` |
+| `ai`                              | Models & intelligence — LLM/prompt-engineering, RAG, NLP, ML, eval          | `ref-md-ai-prompt-engineering`, `ref-md-ai-llm-judge`, `ref-md-ai-ner`           |
+| `api`                             | API contracts & docs (REST, GraphQL, OpenAPI)                               | `ref-md-api-docs`                                                                |
+| `infra`                           | CI/CD, deployment, infrastructure                                           | `ref-md-infra-ci`, `ref-md-infra-terraform`                                      |
+| `dev`                             | Cross-cutting engineering practice (dev-facing): code quality, git/PR, docs | `ref-md-dev-coding-patterns`, `ref-md-dev-workflow`                              |
+| `biz`                             | Business / cross-department process                                         | `ref-md-biz-tasks-management`                                                    |
+| `agents`                          | The agent/skills system itself                                              | `ref-md-agents-skills-authoring`, `ref-md-agents-security`                       |
+| `repo`                            | One specific repository                                                     | `ref-md-repo-dev-tools`, `ref-md-repo-mindoktor-testing`                         |
+
+## Two tests for "does X deserve its own domain?"
+
+A token earns a domain only if it passes **both**:
+
+1. **Clear boundary** — you can place a skill in it without agonizing (low overlap with other domains).
+2. **Proportionate volume** — enough actual or expected skills to justify a bucket, not one lonely skill.
+
+Fail either → fold it into a broader domain, and revisit if it grows (see "Adding a domain later"). This is why `llm`/`nlp`/`ml` collapsed into `ai` (heavy mutual overlap + tiny volume), while `data` stayed separate (clean boundary, distinct discipline).
+
+## Tie-breakers (the calls that actually recur)
+
+| Unsure between…          | Rule                                                                                                                                                                | Example                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| a language vs `dev`      | Tied to one language → the language; applies across languages → `dev`                                                                                               | "const arrow functions" → `js`; "leave code better" → `dev` |
+| `dev` vs `biz`           | Audience: developer-only → `dev`; POs/designers also touch it → `biz`                                                                                               | PR conventions → `dev`; Jira story authoring → `biz`        |
+| `db` vs `data`           | Where data *lives* (schema, migrations) → `db`; what you *do* with it → `data`                                                                                      | migration files → `db`; anonymization → `data`              |
+| `data` vs `ai`           | "Could it exist with no model?" Yes → `data`; inherently about a model → `ai`                                                                                       | PII pipeline → `data`; NER → `ai`                           |
+| `api` vs `infra`         | The contract/docs → `api`; the pipeline that builds/ships it → `infra`                                                                                              | OpenAPI spec → `api`; deploy workflow → `infra`             |
+| `agents` vs `dev`        | About the *skills/agent system* → `agents`; about building the *product* → `dev`/lang                                                                               | skill-authoring → `agents`; product code style → `dev`      |
+| `repo` vs a topic domain | "How *this repo* works" → `repo`; a reusable convention that merely lives there → the topic domain (keep repo-specific bits in the `repo`/app skill — base + delta) | mindoktor build quirks → `repo`; generic React rules → `js` |
+
+## Concerns are not domains
+
+Some things are **activities you perform on a subject**, not knowledge areas. They attach to the domain that owns the subject (plus the audience) — they never get their own domain:
+
+| Concern             | Where it goes                                                                          |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| Documentation       | engineering docs → `dev`; API docs → `api`; skill docs → `agents`; user-facing → `biz` |
+| Testing             | unit tests → the language (`js`); e2e → the testing `repo`                             |
+| Git / commits / PRs | `dev` (the workflow practice)                                                          |
+| Code review         | `dev`                                                                                  |
+
+If you are tempted to add `docs`, `testing`, `git`, or `review` as a domain, that is the signal it is a concern — route it to the owning domain instead.
+
+## Adding a domain later
+
+When a folded area genuinely grows (several skills **and** a clean boundary — e.g. `ai` splitting into `ai-llm` vs `ai-nlp`, or a real technical-writing practice earning `docs`): add the token to `ALLOWED_DOMAINS` in `ref-md-agents-shareable-skills`'s `scripts/validateSharing.mts` **and** the table in [`../SKILL.md`](../SKILL.md) in the same change. Keep language tokens short (`js`, `go`, `py`).

--- a/.claude/skills/ref-md-agents-skills-authoring/references/evaluating-skills.md
+++ b/.claude/skills/ref-md-agents-skills-authoring/references/evaluating-skills.md
@@ -1,0 +1,226 @@
+# Evaluating Skill Output Quality
+
+Reference: <https://agentskills.io/skill-creation/evaluating-skills>
+
+Run structured evaluations (evals) to test whether a skill produces good outputs reliably — across varied prompts, in edge cases, and better than no skill at all.
+
+## Designing Test Cases
+
+A test case has three parts:
+
+- **Prompt**: a realistic user message — the kind of thing someone would actually type.
+- **Expected output**: a human-readable description of what success looks like.
+- **Input files** (optional): files the skill needs to work with.
+
+Store test cases in `evals/evals.json` inside the skill directory:
+
+```json
+{
+  "skill_name": "my-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Realistic user message with file paths and context...",
+      "expected_output": "Human-readable success description.",
+      "files": ["evals/files/input.csv"]
+    },
+    {
+      "id": 2,
+      "prompt": "A casual phrasing of a different scenario...",
+      "expected_output": "What the output should contain or achieve.",
+      "files": []
+    }
+  ]
+}
+```
+
+Tips for writing good test prompts:
+
+- **Start with 2-3 test cases.** Don't over-invest before the first round of results.
+- **Vary the prompts.** Different phrasings, levels of detail, and formality. Some casual, others precise.
+- **Cover edge cases.** At least one prompt that tests a boundary condition — malformed input, unusual request, or ambiguous instructions.
+- **Use realistic context.** Real users mention file paths, column names, and personal context. "Process this data" is too vague to test anything.
+
+## Running Evals
+
+Run each test case twice: once **with** the skill and once **without** it (or with a previous version). This gives a baseline to compare against.
+
+### Workspace Structure
+
+```text
+my-skill/
+├── SKILL.md
+└── evals/
+    └── evals.json
+my-skill-workspace/
+└── iteration-1/
+    ├── eval-test-case-1/
+    │   ├── with_skill/
+    │   │   ├── outputs/
+    │   │   ├── timing.json
+    │   │   └── grading.json
+    │   └── without_skill/
+    │       ├── outputs/
+    │       ├── timing.json
+    │       └── grading.json
+    ├── eval-test-case-2/
+    │   └── ...
+    └── benchmark.json
+```
+
+### Spawning Runs
+
+Each eval run should start with a clean context — no leftover state. In environments that support subagents, this isolation comes naturally. Without subagents, use a separate session for each run.
+
+For each run, provide:
+
+- The skill path (or no skill for the baseline)
+- The test prompt
+- Any input files
+- The output directory
+
+### Capturing Timing Data
+
+Record token count and duration after each run:
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332
+}
+```
+
+## Writing Assertions
+
+Add assertions after you see the first round of outputs — you often don't know what "good" looks like until the skill has run.
+
+Good assertions:
+
+- `"The output file is valid JSON"` — programmatically verifiable
+- `"The bar chart has labeled axes"` — specific and observable
+- `"The report includes at least 3 recommendations"` — countable
+
+Weak assertions:
+
+- `"The output is good"` — too vague to grade
+- `"The output uses exactly the phrase 'Total Revenue: $X'"` — too brittle
+
+Add assertions to each test case in `evals/evals.json`:
+
+```json
+{
+  "id": 1,
+  "prompt": "...",
+  "expected_output": "...",
+  "assertions": [
+    "The output includes a chart image file",
+    "Both axes are labeled",
+    "The chart title mentions revenue"
+  ]
+}
+```
+
+Not everything needs an assertion. Writing style, visual design, and "does this feel right" are better caught during human review.
+
+## Grading Outputs
+
+Grade each assertion against the actual outputs. Record PASS or FAIL with **specific evidence** — quote or reference the output, don't just state an opinion.
+
+```json
+{
+  "assertion_results": [
+    {
+      "text": "The output includes a chart image file",
+      "passed": true,
+      "evidence": "Found chart.png (45KB) in outputs directory"
+    },
+    {
+      "text": "Both axes are labeled",
+      "passed": false,
+      "evidence": "Y-axis labeled 'Revenue ($)' but X-axis has no label"
+    }
+  ],
+  "summary": {
+    "passed": 1,
+    "failed": 1,
+    "total": 2,
+    "pass_rate": 0.50
+  }
+}
+```
+
+Grading principles:
+
+- **Require concrete evidence for a PASS.** Don't give the benefit of the doubt.
+- **Review the assertions themselves** — notice when assertions are too easy, too hard, or unverifiable.
+- For comparing two skill versions, try **blind comparison**: present both outputs to an LLM judge without revealing which version produced each.
+
+## Aggregating Results
+
+Compute summary statistics per configuration:
+
+```json
+{
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": { "mean": 0.83 },
+      "tokens": { "mean": 3800 }
+    },
+    "without_skill": {
+      "pass_rate": { "mean": 0.33 },
+      "tokens": { "mean": 2100 }
+    },
+    "delta": {
+      "pass_rate": 0.50,
+      "tokens": 1700
+    }
+  }
+}
+```
+
+The `delta` tells you what the skill costs (more tokens) and what it buys (higher pass rate). A skill that adds tokens but improves pass rate by 50 percentage points is worth it. A skill that doubles token usage for a 2-point improvement might not be.
+
+## Analyzing Patterns
+
+After aggregating:
+
+- **Remove assertions that always pass in both configurations** — they don't reflect skill value.
+- **Investigate assertions that always fail in both** — broken assertion, too-hard test, or wrong check.
+- **Study assertions that pass with skill but fail without** — this is where the skill adds value.
+- **Tighten instructions for inconsistent results** — if the same eval passes sometimes and fails others, the skill may be ambiguous.
+- **Check token outliers** — read execution transcripts to find bottlenecks.
+
+## Blind Comparison
+
+For a more rigorous comparison between two skill versions, use blind evaluation: present both outputs to an independent LLM judge labeled "A" and "B" — without revealing which version produced each. The judge evaluates on a rubric:
+
+1. **Content**: correctness, completeness, accuracy (1-5 each).
+2. **Structure**: organization, formatting, usability (1-5 each).
+3. **Overall**: combined score scaled to 1-10.
+
+The judge picks a winner with specific evidence. If assertions are available, check them against both outputs as secondary evidence — rubric scores take priority.
+
+After the blind comparison, an unblinded analysis step reads both skills and execution traces to understand *why* the winner won: clearer instructions, better scripts, more comprehensive examples. This produces actionable improvement suggestions for the loser.
+
+Blind comparison is optional and most useful when:
+
+- Aggregate metrics are close and you need a tiebreaker.
+- You suspect the skill is helping for the wrong reasons.
+- You want to eliminate confirmation bias in human review.
+
+## The Iteration Loop
+
+1. Give the eval signals and current `SKILL.md` to an LLM and ask it to propose improvements.
+2. Review and apply the changes.
+3. Rerun all test cases in a new `iteration-<N+1>/` directory.
+4. Grade and aggregate the new results.
+5. Review with a human. Repeat.
+
+Stop when you're satisfied, feedback is consistently empty, or improvements plateau.
+
+Guidelines for each iteration:
+
+- **Generalize from feedback** — fixes should address underlying issues, not narrow patches for specific examples.
+- **Keep the skill lean** — fewer, better instructions often outperform exhaustive rules.
+- **Explain the why** — reasoning-based instructions work better than rigid directives.
+- **Bundle repeated work** — if every run independently writes the same helper logic, put it in `scripts/`.

--- a/.claude/skills/ref-md-agents-skills-authoring/references/optimizing-descriptions.md
+++ b/.claude/skills/ref-md-agents-skills-authoring/references/optimizing-descriptions.md
@@ -1,0 +1,134 @@
+# Optimizing Skill Descriptions
+
+Reference: <https://agentskills.io/skill-creation/optimizing-descriptions>
+
+A skill only helps if it gets activated. The `description` field in SKILL.md frontmatter is the primary mechanism agents use to decide whether to load a skill. An under-specified description means the skill won't trigger when it should; an over-broad description means it triggers when it shouldn't.
+
+## How Triggering Works
+
+Agents use progressive disclosure: at startup, they load only `name` and `description` of each skill — just enough to decide relevance. The full SKILL.md loads only when a task matches.
+
+Important nuance: agents typically only consult skills for tasks that require knowledge or capabilities beyond what they can handle alone. A simple request like "read this PDF" may not trigger a PDF skill even with a perfect description, because the agent handles it with basic tools. Skills shine on specialized knowledge — unfamiliar APIs, domain-specific workflows, uncommon formats.
+
+## Writing Effective Descriptions
+
+- **Imperative phrasing**: "Use this skill when…" — the agent is deciding whether to act.
+- **Focus on user intent**: what the user is trying to achieve, not the skill's internals.
+- **Be pushy**: explicitly list contexts, including cases where the user doesn't name the domain directly.
+- **Stay under 1024 characters**: this is the hard spec limit.
+
+Before and after:
+
+```yaml
+# Before
+description: Process CSV files.
+
+# After
+description: >-
+  Analyze CSV and tabular data files — compute summary statistics,
+  add derived columns, generate charts, and clean messy data. Use this
+  skill when the user has a CSV, TSV, or Excel file and wants to
+  explore, transform, or visualize the data, even if they don't
+  explicitly mention "CSV" or "analysis."
+```
+
+## Designing Trigger Eval Queries
+
+Create ~20 eval queries: 8-10 should-trigger, 8-10 should-not-trigger. Store them in a JSON file:
+
+```json
+[
+  { "query": "I've got a spreadsheet in ~/data/q4_results.xlsx with revenue in col C and expenses in col D — can you add a profit margin column and highlight anything under 10%?", "should_trigger": true },
+  { "query": "whats the quickest way to convert this json file to yaml", "should_trigger": false }
+]
+```
+
+### Should-trigger queries
+
+Vary along several axes:
+
+- **Phrasing**: formal, casual, typos, abbreviations.
+- **Explicitness**: some name the domain directly, others describe the need without naming it.
+- **Detail**: mix terse prompts with context-heavy ones including file paths and column names.
+- **Complexity**: single-step tasks alongside multi-step workflows where the skill's domain is buried in a larger chain.
+
+The most useful should-trigger queries are ones where the connection isn't obvious from the query alone.
+
+### Should-not-trigger queries
+
+The most valuable negatives are **near-misses** — queries that share keywords but need something different:
+
+- Weak: `"Write a fibonacci function"` — obviously irrelevant, tests nothing.
+- Strong: `"can you write a python script that reads a csv and uploads each row to our postgres database"` — involves CSV, but the task is ETL, not analysis.
+
+### Tips for realism
+
+Real user prompts include file paths (`~/Downloads/report_final_v2.xlsx`), personal context (`"my manager asked me to…"`), specific details (column names, company names), and casual language.
+
+## Testing Trigger Rates
+
+Run each query through your agent with the skill installed and observe whether the agent loads the skill. Run each query **3+ times** (model behavior is nondeterministic) and compute a trigger rate:
+
+- **Should-trigger**: passes if trigger rate > 0.5.
+- **Should-not-trigger**: passes if trigger rate < 0.5.
+
+General script structure (adapt the detection logic to your agent client):
+
+```bash
+#!/bin/bash
+QUERIES_FILE="${1:?Usage: $0 <queries.json>}"
+SKILL_NAME="my-skill"
+RUNS=3
+
+count=$(jq length "$QUERIES_FILE")
+for i in $(seq 0 $((count - 1))); do
+  query=$(jq -r ".[$i].query" "$QUERIES_FILE")
+  should_trigger=$(jq -r ".[$i].should_trigger" "$QUERIES_FILE")
+  triggers=0
+
+  for run in $(seq 1 $RUNS); do
+    # Replace with your agent client's detection logic:
+    # returns 0 if skill was invoked, 1 otherwise
+    check_triggered "$query" && triggers=$((triggers + 1))
+  done
+
+  jq -n \
+    --arg query "$query" \
+    --argjson should_trigger "$should_trigger" \
+    --argjson triggers "$triggers" \
+    --argjson runs "$RUNS" \
+    '{query: $query, should_trigger: $should_trigger, triggers: $triggers, runs: $runs, trigger_rate: ($triggers / $runs)}'
+done | jq -s '.'
+```
+
+With 20 queries at 3 runs each, that's 60 invocations. Scripting is essential.
+
+## Avoiding Overfitting
+
+Split your query set to prevent overfitting to specific phrasings:
+
+- **Train set (~60%)**: queries you use to identify failures and guide improvements.
+- **Validation set (~40%)**: queries you set aside and only use to check whether improvements generalize.
+
+Both sets must contain a proportional mix of should-trigger and should-not-trigger queries. Keep the split fixed across iterations.
+
+## The Optimization Loop
+
+1. **Evaluate** the current description on both train and validation sets. Train results guide changes; validation results tell you whether changes generalize.
+2. **Identify failures** in the train set only. Which should-trigger queries didn't trigger? Which should-not-trigger queries did?
+3. **Revise the description**:
+   - Should-trigger failures → description may be too narrow. Broaden the scope or add context about when the skill is useful.
+   - Should-not-trigger failures → description may be too broad. Add specificity about what the skill does *not* do, or clarify the boundary with adjacent capabilities.
+   - **Avoid adding specific keywords from failed queries** — that's overfitting. Find the general category those queries represent and address that.
+   - If stuck after several iterations, try a structurally different description rather than incremental tweaks.
+   - Check the description stays under 1024 characters — descriptions grow during optimization.
+4. **Repeat** steps 1-3 until all train set queries pass or improvement plateaus.
+5. **Select the best iteration** by validation pass rate — not necessarily the last one. Earlier iterations may generalize better than later ones that overfit to the train set.
+
+Five iterations is usually enough. If performance isn't improving, the issue may be with the queries (too easy, too hard, or poorly labeled) rather than the description.
+
+## Applying the Result
+
+1. Update the `description` field in SKILL.md frontmatter.
+2. Verify it's under 1024 characters.
+3. Sanity check with 5-10 **fresh queries** (never used during optimization) — a mix of should-trigger and should-not-trigger. These give an honest check on generalization.

--- a/.claude/skills/ref-md-agents-skills-authoring/references/tool-skills.md
+++ b/.claude/skills/ref-md-agents-skills-authoring/references/tool-skills.md
@@ -1,0 +1,84 @@
+# Tool Skills
+
+Use this reference when creating or reviewing skills whose name starts with `tool-`.
+
+## What Makes a Tool Skill Different
+
+A tool skill is not just a topic area. It exists to **perform an action while eliciting the right knowledge, constraints, and workflow from the agent**.
+
+Examples of well-named tool skills:
+
+- `tool-md-create-db-migration` — create a database migration while loading naming conventions, SQL patterns, and testing workflow
+- `tool-md-maintain-skills` — audit and maintain skills while loading compliance, freshness, and deduplication rules
+- `tool-md-create-task` — create a Jira task while loading task templates, refinement questions, and workflow
+- `tool-md-update-siths-certificate` — update a local certificate while loading K8s context and file placement rules
+
+The **name** should state the action. The **body** should encode the knowledge the agent needs to perform that action correctly.
+
+## Naming Rule
+
+See the **Naming Conventions** section in [`SKILL.md`](../SKILL.md) for the full `tool-` / `ref-` taxonomy, naming patterns, and decision heuristic.
+
+## Description Pattern
+
+The description for a tool skill should do two jobs:
+
+1. State the action the skill performs.
+2. State the knowledge, workflow, or constraints it loads so the agent can perform that action correctly.
+
+### Good pattern
+
+```yaml
+description: >-
+  Commit pending changes with focused, well-structured commits.
+  Use when: the user asks to commit, or after completing a unit of work.
+  Analyzes the working tree, groups related files, runs project checks,
+  and follows GPG signing discipline.
+```
+
+This works because the first sentence names the action (`Commit`), while the rest explains the knowledge it loads (grouping, checks, GPG discipline).
+
+## Anatomy of a Strong Tool Skill
+
+Tool skills usually benefit from these sections:
+
+1. **Title** — action-oriented, often `# Tool: <Action>`
+2. **Purpose** — one sentence describing the action
+3. **Prerequisites** — required skills, tools, or setup
+4. **Workflow** — ordered action steps
+5. **Scope** — what the tool skill covers and what it does not
+6. **Related skills** — adjacent tool or domain skills
+
+### Why this structure works
+
+| Section        | Why it matters for tool skills                           | When it is most important                  |
+| -------------- | -------------------------------------------------------- | ------------------------------------------ |
+| Prerequisites  | Tool actions often depend on other skills or CLIs        | Commits, PRs, Jira, security, deployment   |
+| Workflow       | Tool skills benefit from explicit sequencing of actions  | Any multi-step action                      |
+| Scope          | Prevents a tool skill from becoming a vague catch-all    | Broad or reusable tool skills              |
+| Related skills | Tool skills often compose with domain or workflow skills | When the action depends on other knowledge |
+
+## How Tool Skills Elicit Knowledge
+
+A tool skill should not only say *what to do*. It should actively load the knowledge the agent needs to avoid mistakes.
+
+| What the tool skill does  | What knowledge it should elicit                       |
+| ------------------------- | ----------------------------------------------------- |
+| Executes an action        | Concrete workflow steps and stop conditions           |
+| Makes decisions           | Trade-offs, defaults, and selection rules             |
+| Uses external tools       | Invocation patterns, flags, expected outputs          |
+| Writes or edits artifacts | Structure, templates, registration, validation checks |
+| Risks side effects        | Safety constraints, approvals, validation loops       |
+
+This is why `tool-md-create-db-migration` is not just "run goose create" and `tool-md-maintain-skills` is not just "check the checklist." The skill exists to inject judgment and process, not merely a command.
+
+## Checklist for Tool Skills
+
+When reviewing a tool skill, ask:
+
+- Does the name clearly describe the action?
+- Does the description start with the action and then explain the loaded knowledge?
+- Does the workflow show how the agent performs the action safely?
+- Does the skill load any prerequisite skills or references explicitly?
+- Does the skill say what the action does **not** cover?
+- Would a different tool skill name trigger more precisely?

--- a/.claude/skills/ref-md-agents-skills-authoring/references/using-scripts.md
+++ b/.claude/skills/ref-md-agents-skills-authoring/references/using-scripts.md
@@ -1,0 +1,81 @@
+# Using Scripts in Skills
+
+Reference: <https://agentskills.io/skill-creation/using-scripts>
+
+Skills can instruct agents to run shell commands and bundle reusable scripts in a `scripts/` directory.
+
+## One-Off Commands
+
+When an existing package already does what you need, reference it directly in `SKILL.md` without a `scripts/` directory. Use runtime-resolving tools:
+
+| Tool       | Ecosystem | Example                   |
+| ---------- | --------- | ------------------------- |
+| `uvx`      | Python    | `uvx ruff@0.8.0 check .`  |
+| `npx`      | Node.js   | `npx eslint@9.0.0 .`      |
+| `bunx`     | Bun       | `bunx biome check .`      |
+| `deno run` | Deno      | `deno run npm:prettier .` |
+
+Tips:
+
+- **Pin versions** so behavior is stable over time.
+- **State prerequisites** in `SKILL.md` (e.g. "Requires Node.js 18+") or use the `compatibility` frontmatter field.
+- **Move complex commands into scripts** — a one-off works for simple tool invocations, not multi-step logic.
+
+## Self-Contained Scripts
+
+Bundle scripts in `scripts/` that declare their own dependencies inline. The agent runs them with a single command — no separate install step.
+
+### Python (PEP 723)
+
+```python
+# /// script
+# dependencies = ["beautifulsoup4>=4.12,<5"]
+# requires-python = ">=3.11"
+# ///
+
+from bs4 import BeautifulSoup
+# ...
+```
+
+Run with: `uv run scripts/extract.py`
+
+Use `uv lock --script` to create a lockfile for full reproducibility.
+
+### Deno / Bun
+
+Deno and Bun support inline dependency resolution via import maps or direct URL imports. Use `deno.json` for pinned versions.
+
+## Referencing Scripts from SKILL.md
+
+List available scripts so the agent knows they exist:
+
+```markdown
+## Available scripts
+
+- **`scripts/validate.sh`** — Validates configuration files
+- **`scripts/process.py`** — Processes input data
+```
+
+Then instruct the agent to run them with relative paths:
+
+```markdown
+## Workflow
+
+1. Run validation: `bash scripts/validate.sh "$INPUT_FILE"`
+2. Process results: `python3 scripts/process.py --input results.json`
+```
+
+Relative paths work from the skill directory root. The same convention works in reference files.
+
+## Designing Scripts for Agentic Use
+
+Agents read stdout and stderr to decide what to do next. A few design choices make scripts dramatically easier for agents to use:
+
+- **No interactive prompts** — agents run in non-interactive shells. Accept all input via flags, environment variables, or stdin.
+- **Document with `--help`** — this is how agents learn the interface. Include description, available flags, and usage examples. Keep it concise.
+- **Helpful error messages** — say what went wrong, what was expected, and what to try.
+- **Structured output** — JSON/CSV over free-form text. Data to stdout, diagnostics to stderr.
+- **Idempotency** — agents may retry. "Create if not exists" is safer than "create and fail on duplicate."
+- **Meaningful exit codes** — use distinct codes for different failure types and document them in `--help`.
+- **Predictable output size** — default to summaries and support `--offset` or `--output FILE` for large results.
+- **Dry-run support** — for destructive or stateful operations, a `--dry-run` flag lets the agent preview what will happen.

--- a/.claude/skills/ref-md-agents-skills-authoring/scripts/alignTables.mts
+++ b/.claude/skills/ref-md-agents-skills-authoring/scripts/alignTables.mts
@@ -1,0 +1,266 @@
+/**
+ * Align markdown tables so all pipe characters sit at the same column positions.
+ *
+ * Usage:
+ *   node alignTables.mts <file> [--write | --check]
+ *
+ * Default (no flag): prints the aligned file to stdout for review.
+ * --write: edits the file in place.
+ * --check: exits non-zero if the file is not already aligned; edits nothing.
+ *
+ * The core is exported (`alignMarkdownTables`) so the skills validator can reuse
+ * it to enforce alignment without shelling out or duplicating the logic.
+ */
+
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/** A contiguous block of markdown table lines (header, separator, data rows). */
+interface TableBlock {
+  /** 0-based line index where the table starts in the file. */
+  start: number;
+  /** The raw lines that make up the table. */
+  lines: string[];
+}
+
+/**
+ * Split a line on pipe characters and return the trimmed inner cells.
+ * Pipes escaped as `\|` are literal cell content (e.g. regex alternation in the
+ * auto-approve skill), not column separators, so they are kept intact. Raw,
+ * unescaped pipes inside code spans are still not handled — escape them as `\|`.
+ */
+const splitRow = (line: string): string[] => {
+  const trimmed = line.trim();
+  const withoutOuterPipes = trimmed.replace(/^\|/, '').replace(/\|$/, '');
+  return withoutOuterPipes.split(/(?<!\\)\|/).map((cell) => cell.trim());
+};
+
+/** True when the line looks like a separator row: `|---|---|`. */
+const isSeparator = (line: string): boolean =>
+  /^\|[\s:]*-+[\s:]*(\|[\s:]*-+[\s:]*)*\|?\s*$/.test(line.trim());
+
+/** True when the line looks like a table row: starts and ends with `|`. */
+const isTableRow = (line: string): boolean => {
+  const trimmed = line.trim();
+  return trimmed.startsWith('|') && trimmed.endsWith('|');
+};
+
+/** True when the line opens or closes a fenced code block (``` or ~~~). */
+const isCodeFence = (line: string): boolean => /^\s*(```|~~~)/.test(line);
+
+/** Find all contiguous table blocks in the file. */
+const findTables = (lines: string[]): TableBlock[] => {
+  const tables: TableBlock[] = [];
+  let i = 0;
+  let inCodeFence = false;
+
+  while (i < lines.length) {
+    // Skip fenced code blocks so pipe-heavy code is never parsed as a table.
+    if (isCodeFence(lines[i])) {
+      inCodeFence = !inCodeFence;
+      i++;
+      continue;
+    }
+
+    // A table starts when we see a row followed by a separator row.
+    if (
+      !inCodeFence &&
+      isTableRow(lines[i]) &&
+      i + 1 < lines.length &&
+      isSeparator(lines[i + 1])
+    ) {
+      const start = i;
+      const block: string[] = [];
+
+      // Consume all contiguous table rows.
+      while (i < lines.length && isTableRow(lines[i])) {
+        block.push(lines[i]);
+        i++;
+      }
+
+      tables.push({ start, lines: block });
+      continue;
+    }
+
+    i++;
+  }
+
+  return tables;
+};
+
+// ---------------------------------------------------------------------------
+// Alignment
+// ---------------------------------------------------------------------------
+
+/** Build a separator cell of the right width, preserving alignment markers. */
+const buildSeparatorCell = (original: string, width: number): string => {
+  const trimmed = original.trim();
+  const leftColon = trimmed.startsWith(':');
+  const rightColon = trimmed.endsWith(':');
+
+  const dashes = width - (leftColon ? 1 : 0) - (rightColon ? 1 : 0);
+  return (
+    (leftColon ? ':' : '') +
+    '-'.repeat(Math.max(1, dashes)) +
+    (rightColon ? ':' : '')
+  );
+};
+
+/** Align a single table block. Returns the new lines. */
+const alignTable = (block: string[]): string[] => {
+  const parsed = block.map(splitRow);
+
+  // Number of columns = max across all rows (handles ragged tables).
+  const colCount = Math.max(...parsed.map((row) => row.length));
+
+  // Compute max width per column across all non-separator rows.
+  const widths = new Array<number>(colCount).fill(0);
+  for (let rowIdx = 0; rowIdx < parsed.length; rowIdx++) {
+    if (isSeparator(block[rowIdx])) {
+      continue;
+    }
+    for (let col = 0; col < parsed[rowIdx].length; col++) {
+      widths[col] = Math.max(widths[col], parsed[rowIdx][col].length);
+    }
+  }
+
+  // Ensure minimum width of 3 for separator dashes.
+  for (let col = 0; col < colCount; col++) {
+    widths[col] = Math.max(widths[col], 3);
+  }
+
+  // Rebuild each line.
+  return block.map((line, rowIdx) => {
+    const cells = parsed[rowIdx];
+    const isSep = isSeparator(line);
+
+    const paddedCells = Array.from({ length: colCount }, (_, col) => {
+      const raw = cells[col] ?? '';
+      if (isSep) {
+        return buildSeparatorCell(raw, widths[col]);
+      }
+      return raw.padEnd(widths[col]);
+    });
+
+    return `| ${paddedCells.join(' | ')} |`;
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Align every markdown table in `content` and return the rewritten text. Tables
+ * inside fenced code blocks are left untouched; content with no tables is
+ * returned unchanged. Shared by the CLI and the skills validator so alignment
+ * is defined in exactly one place.
+ */
+export const alignMarkdownTables = (content: string): string => {
+  const lines = content.split('\n');
+  const tables = findTables(lines);
+
+  if (tables.length === 0) {
+    return content;
+  }
+
+  // Apply alignment in reverse order so line indices stay valid.
+  for (let t = tables.length - 1; t >= 0; t--) {
+    const table = tables[t];
+    const aligned = alignTable(table.lines);
+    lines.splice(table.start, table.lines.length, ...aligned);
+  }
+
+  return lines.join('\n');
+};
+
+/** Count the markdown tables in `content` (used only for CLI reporting). */
+export const countMarkdownTables = (content: string): number =>
+  findTables(content.split('\n')).length;
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const printUsage = (): void => {
+  console.log('Usage: node alignTables.mts <file> [--write | --check]');
+  console.log('');
+  console.log(
+    'Align markdown tables so pipe characters sit at consistent columns.',
+  );
+  console.log('  (default)  print the aligned file to stdout for review');
+  console.log('  --write    edit the file in place');
+  console.log(
+    '  --check    exit non-zero (and name the file) if it is not already aligned',
+  );
+};
+
+const main = (): number => {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args.includes('--help')) {
+    printUsage();
+    return args.includes('--help') ? 0 : 1;
+  }
+
+  const filePath = args.find((a) => !a.startsWith('--'));
+  const writeMode = args.includes('--write');
+  const checkMode = args.includes('--check');
+
+  if (filePath == null) {
+    console.error('Error: no file path provided.');
+    printUsage();
+    return 1;
+  }
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`Error: file not found: ${filePath}`);
+    return 1;
+  }
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const aligned = alignMarkdownTables(content);
+  const isAligned = aligned === content;
+
+  if (checkMode) {
+    if (isAligned) {
+      console.log(`OK: ${filePath} tables are aligned`);
+      return 0;
+    }
+    console.error(
+      `FAIL: ${filePath} has misaligned markdown tables — run with --write to fix`,
+    );
+    return 1;
+  }
+
+  if (writeMode) {
+    if (isAligned) {
+      console.log(`No change: ${filePath} tables already aligned`);
+      return 0;
+    }
+    fs.writeFileSync(filePath, aligned, 'utf-8');
+    console.log(
+      `Aligned ${countMarkdownTables(content)} table(s) in ${filePath}`,
+    );
+    return 0;
+  }
+
+  process.stdout.write(aligned);
+  return 0;
+};
+
+// Run the CLI only when invoked directly, never when imported (e.g. by the
+// skills validator). Node sets process.argv[1] to the entry script's path
+// (an empty string when Node is started via --eval), so map it to a file URL
+// only when present and compare against this module's own URL.
+const entryHref = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href
+  : undefined;
+
+if (import.meta.url === entryHref) {
+  process.exit(main());
+}

--- a/.claude/skills/ref-md-agents-skills-authoring/scripts/validateSkills.mts
+++ b/.claude/skills/ref-md-agents-skills-authoring/scripts/validateSkills.mts
@@ -1,0 +1,336 @@
+// Validates skill AUTHORING and STRUCTURE under .claude/skills: folder naming,
+// the frontmatter essentials (name↔folder, description shape, author, version),
+// the SKILL.md line budget, local link targets, markdown table alignment, and
+// stale skill references in the repo instruction index (AGENTS.md, or a legacy
+// .github/copilot-instructions.md). The SHARING / portability
+// metadata (owner-prefix, owner, domain, visibility, requires/suggests, and the
+// dependency graph) is validated separately by ref-md-agents-shareable-skills's
+// scripts/validateSharing.mts — run both.
+//
+// Usage:
+//   node validateSkills.mts [--repo-path <repo-name-or-path>]
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { alignMarkdownTables } from './alignTables.mts';
+
+const scriptPath = fileURLToPath(import.meta.url);
+const scriptDir = path.dirname(scriptPath);
+
+const readRepoPathArg = (argv: string[]): string | null => {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg.startsWith('--repo-path=')) {
+      return arg.slice('--repo-path='.length);
+    }
+    if (arg === '--repo-path') {
+      return argv[index + 1] ?? '';
+    }
+  }
+  return null;
+};
+
+// Resolve a --repo-path value to a repo root: an absolute path is used as-is,
+// a path that exists relative to the current directory is used next, and
+// anything else is treated as a repo name under ~/dev.
+const resolveRepoRoot = (value: string): string => {
+  if (path.isAbsolute(value)) {
+    return value;
+  }
+  const fromCwd = path.resolve(process.cwd(), value);
+  if (fs.existsSync(fromCwd)) {
+    return fromCwd;
+  }
+  return path.join(os.homedir(), 'dev', value);
+};
+
+const repoPathArg = readRepoPathArg(process.argv.slice(2));
+
+// Without --repo-path, validate the repo this script lives in (four levels up
+// from the script). With the flag, validate the named repo instead.
+const ROOT =
+  repoPathArg == null || repoPathArg === ''
+    ? path.resolve(scriptDir, '../../../../')
+    : resolveRepoRoot(repoPathArg);
+const SKILLS_DIR = path.join(ROOT, '.claude', 'skills');
+
+const SKILL_NAME_RE = /^(tool|ref)-[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const FRONTMATTER_NAME_RE = /^name:\s*(.+?)\s*$/;
+const FRONTMATTER_DESC_RE = /^description:\s*/;
+const FRONTMATTER_AUTHOR_RE = /^\s*author:\s*(.+?)\s*$/;
+const FRONTMATTER_VERSION_RE = /^\s*version:\s*(.+?)\s*$/;
+const MARKDOWN_LINK_RE = /\[[^\]]+\]\(([^)]+)\)/g;
+const FENCED_CODE_BLOCK_RE = /```[\s\S]*?```/g;
+
+class CheckResult {
+  failures: string[] = [];
+
+  fail = (message: string): void => {
+    this.failures.push(message);
+  };
+
+  ok = (): boolean => {
+    return this.failures.length === 0;
+  };
+}
+
+const readFrontmatterLines = (skillFile: string): string[] => {
+  const lines = fs.readFileSync(skillFile, 'utf-8').split('\n');
+  if (lines.length < 3 || lines[0].trim() !== '---') {
+    return [];
+  }
+
+  let endIndex = -1;
+  for (let index = 1; index < lines.length; index += 1) {
+    if (lines[index].trim() === '---') {
+      endIndex = index;
+      break;
+    }
+  }
+
+  if (endIndex === -1) {
+    return [];
+  }
+
+  return lines.slice(1, endIndex);
+};
+
+const normalizeLinkTarget = (target: string): string => {
+  return target.split('#', 1)[0].trim();
+};
+
+// Some overlay/sandbox filesystems return Dirents without populated type
+// info, so entry.isDirectory() is unreliable. Stat the path to be safe.
+const isDirectory = (target: string): boolean => {
+  try {
+    return fs.statSync(target).isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+const listDirectories = (dir: string): string[] => {
+  return fs
+    .readdirSync(dir)
+    .map((entry) => path.join(dir, entry))
+    .filter(isDirectory)
+    .sort((a, b) => a.localeCompare(b));
+};
+
+const listMarkdownFilesRecursively = (dir: string): string[] => {
+  const files: string[] = [];
+
+  const walk = (currentDir: string): void => {
+    const entries = fs.readdirSync(currentDir);
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry);
+      if (isDirectory(fullPath)) {
+        walk(fullPath);
+        continue;
+      }
+      if (fullPath.endsWith('.md')) {
+        files.push(fullPath);
+      }
+    }
+  };
+
+  walk(dir);
+  return files.sort((a, b) => a.localeCompare(b));
+};
+
+const validateSkillDir = (skillDir: string, result: CheckResult): void => {
+  const skillName = path.basename(skillDir);
+
+  if (!SKILL_NAME_RE.test(skillName)) {
+    result.fail(
+      `${skillDir}: invalid folder name; expected tool-/ref- kebab-case`,
+    );
+  }
+
+  const skillFile = path.join(skillDir, 'SKILL.md');
+  if (!fs.existsSync(skillFile)) {
+    result.fail(`${skillDir}: missing SKILL.md`);
+    return;
+  }
+
+  const lines = fs.readFileSync(skillFile, 'utf-8').split('\n');
+  if (lines.length > 500) {
+    result.fail(`${skillFile}: exceeds 500 lines (${lines.length})`);
+  }
+
+  const frontmatter = readFrontmatterLines(skillFile);
+  if (frontmatter.length === 0) {
+    result.fail(`${skillFile}: missing or invalid YAML frontmatter`);
+    return;
+  }
+
+  let nameValue: string | null = null;
+  let hasDescription = false;
+  let hasAuthor = false;
+  let hasVersion = false;
+  const frontmatterText = frontmatter.join('\n');
+
+  for (const line of frontmatter) {
+    const nameMatch = FRONTMATTER_NAME_RE.exec(line);
+    if (nameMatch != null) {
+      nameValue = nameMatch[1].trim().replace(/^['"']|['"']$/g, '');
+    }
+    if (FRONTMATTER_DESC_RE.test(line)) {
+      hasDescription = true;
+    }
+    if (FRONTMATTER_AUTHOR_RE.test(line)) {
+      hasAuthor = true;
+    }
+    if (FRONTMATTER_VERSION_RE.test(line)) {
+      hasVersion = true;
+    }
+  }
+
+  if (nameValue !== skillName) {
+    result.fail(
+      `${skillFile}: frontmatter name '${String(nameValue)}' != folder name '${skillName}'`,
+    );
+  }
+
+  if (!hasDescription) {
+    result.fail(`${skillFile}: missing frontmatter description`);
+  }
+
+  if (!frontmatterText.includes('Use when:')) {
+    result.fail(`${skillFile}: description should include 'Use when:'`);
+  }
+
+  if (!frontmatterText.includes('Covers')) {
+    result.fail(`${skillFile}: description should include 'Covers'`);
+  }
+
+  if (!hasAuthor) {
+    result.fail(`${skillFile}: missing metadata.author`);
+  }
+
+  if (!hasVersion) {
+    result.fail(`${skillFile}: missing metadata.version`);
+  }
+};
+
+const validateLinks = (markdownFile: string, result: CheckResult): void => {
+  // Strip fenced code blocks: links inside them are sample output or
+  // illustrations (e.g. CLI snapshot paths), not real documentation links.
+  const text = fs
+    .readFileSync(markdownFile, 'utf-8')
+    .replace(FENCED_CODE_BLOCK_RE, '');
+
+  for (const match of text.matchAll(MARKDOWN_LINK_RE)) {
+    const rawTarget = normalizeLinkTarget(match[1]);
+    if (rawTarget === '') {
+      continue;
+    }
+    if (
+      rawTarget.startsWith('http://') ||
+      rawTarget.startsWith('https://') ||
+      rawTarget.startsWith('mailto:') ||
+      rawTarget.startsWith('#')
+    ) {
+      continue;
+    }
+
+    const resolved = path.resolve(path.dirname(markdownFile), rawTarget);
+    if (!fs.existsSync(resolved)) {
+      const relativeFile = path.relative(ROOT, markdownFile);
+      result.fail(`${relativeFile}: broken local link target '${rawTarget}'`);
+    }
+  }
+};
+
+// Enforce the aligned-table convention: a file fails if alignTables would
+// change it. The fix is mechanical — run alignTables.mts --write on the file.
+const validateTableAlignment = (
+  markdownFile: string,
+  result: CheckResult,
+): void => {
+  const content = fs.readFileSync(markdownFile, 'utf-8');
+  if (alignMarkdownTables(content) !== content) {
+    const relativeFile = path.relative(ROOT, markdownFile);
+    result.fail(
+      `${relativeFile}: markdown tables not aligned — run 'node .claude/skills/ref-md-agents-skills-authoring/scripts/alignTables.mts ${relativeFile} --write'`,
+    );
+  }
+};
+
+// The repo instruction index is a root AGENTS.md by default; older repos may
+// still keep it at .github/copilot-instructions.md. Prefer AGENTS.md, fall back
+// to the legacy path so this check keeps working during the transition.
+const INSTRUCTION_INDEX_CANDIDATES = [
+  path.join(ROOT, 'AGENTS.md'),
+  path.join(ROOT, '.github', 'copilot-instructions.md'),
+];
+const SKILL_REF_RE = /`((?:ref|tool)-[a-z0-9]+(?:-[a-z0-9]+)*)`/g;
+
+const validateInstructionIndexRefs = (result: CheckResult): void => {
+  const indexFile = INSTRUCTION_INDEX_CANDIDATES.find((candidate) =>
+    fs.existsSync(candidate),
+  );
+  if (indexFile == null) {
+    return;
+  }
+
+  const existingSkills = new Set(
+    fs
+      .readdirSync(SKILLS_DIR)
+      .filter((entry) => isDirectory(path.join(SKILLS_DIR, entry))),
+  );
+
+  const relativeIndex = path.relative(ROOT, indexFile);
+  const text = fs.readFileSync(indexFile, 'utf-8');
+  for (const match of text.matchAll(SKILL_REF_RE)) {
+    const skillName = match[1];
+    if (!existingSkills.has(skillName)) {
+      result.fail(`${relativeIndex}: stale skill reference '${skillName}'`);
+    }
+  }
+};
+
+const main = (): number => {
+  const result = new CheckResult();
+
+  if (repoPathArg != null && repoPathArg !== '') {
+    console.log(`Validating skills in ${ROOT}`);
+  }
+
+  if (!fs.existsSync(SKILLS_DIR)) {
+    console.error(`ERROR: .claude/skills directory not found in ${ROOT}`);
+    return 1;
+  }
+
+  for (const skillDir of listDirectories(SKILLS_DIR)) {
+    validateSkillDir(skillDir, result);
+  }
+
+  for (const markdownFile of listMarkdownFilesRecursively(SKILLS_DIR)) {
+    validateTableAlignment(markdownFile, result);
+    // Template placeholders intentionally include non-resolving sample links.
+    if (path.basename(markdownFile) === 'template.md') {
+      continue;
+    }
+    validateLinks(markdownFile, result);
+  }
+
+  validateInstructionIndexRefs(result);
+
+  if (result.ok()) {
+    console.log('OK: all skill checks passed');
+    return 0;
+  }
+
+  console.log('FAIL: skill checks found issues');
+  for (const failure of result.failures) {
+    console.log(`- ${failure}`);
+  }
+
+  return 1;
+};
+
+process.exit(main());

--- a/.claude/skills/ref-md-agents-verification-discipline/SKILL.md
+++ b/.claude/skills/ref-md-agents-verification-discipline/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: ref-md-agents-verification-discipline
+description: >-
+  Portable verification discipline that counters jumping to answers, sycophancy,
+  and overconfidence: enumerate candidate approaches or root causes, route
+  verification by confidence and stakes, prune on evidence, abstain explicitly
+  when nothing can settle a claim. Use when: choosing between approaches or root
+  causes, acting on an unverified claim or assumption, responding when the user
+  challenges or contradicts a conclusion, deciding how much verification a risky
+  or irreversible action needs, or calibrating stated confidence in answers,
+  reviews, and reports. Covers the two dials (confidence and stakes), the
+  enumerate/route/prune/abstain workflow, handling human claims without
+  flipping or digging in, and calibrating stated confidence.
+metadata:
+  author: mindoktor
+  version: "1.0"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "agents"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+  shareable-skills.suggests: "ref-md-agents-mr-wolf-persona, ref-md-dev-coding-patterns"
+  shareable-skills.forked-from: "swiftpostlabs/agentic-tools@88640d3"
+---
+
+# Verification Discipline
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+## Purpose
+
+Give the agent one verification-routing policy that counters both failure directions of the same
+defect — accepting a claim without checking it against external ground truth. Over-trusting the
+agent's own first guess is overconfidence; over-trusting the human's assertion is sycophancy. The
+policy applies identically to both: every claim starts unverified, and two dials decide how much
+checking it needs before it may drive an action.
+
+This is the **method** behind the stance in `ref-md-agents-mr-wolf-persona`. That skill says *why you
+do not capitulate and do not dig in*; this one says *what check settles it*.
+
+## When to use this skill
+
+- Committing to an approach for a task or a suspected root cause for a bug.
+- Acting on a claim that has not been checked against code, docs, or a test.
+- The user challenges, contradicts, or corrects a stated conclusion.
+- Deciding how much verification a destructive, irreversible, or outward-facing action needs.
+- Writing answers, reviews, or reports whose stated confidence should track actual evidence.
+
+## Scope boundaries
+
+This skill owns the **method**: how much checking a claim needs, how to enumerate candidates, how to
+prune on evidence, and when to abstain.
+
+- `ref-md-agents-mr-wolf-persona` — the **stance** the method serves: report what is true rather than
+  what lands well, and change position on evidence rather than pressure. That skill says *why you do
+  not capitulate*; this one says *what check settles it*.
+- `ref-md-dev-coding-patterns` — verifying that a comment's claim matches the code it describes.
+- The owning skill for whatever is being verified. This skill routes the checking; it does not
+  replace the domain knowledge that says what "correct" looks like (e.g. `ref-md-js-cve` for whether
+  a CVE fix is actually right, `ref-md-go-golang` for whether an interface is placed correctly).
+
+## The Two Dials
+
+- **Confidence** — how likely is this claim to be wrong?
+- **Stakes** — what does being wrong cost? Destructive, irreversible, or outward-facing actions
+  (deletes, overwrites, pushes, publishes, migrations, sends, posting to a PR or a Jira ticket) are
+  high-stakes.
+- **Coupling rule** — stakes set the *required* confidence; verification is how confidence is
+  raised. High stakes escalate to the strongest feasible check regardless of felt confidence.
+
+Fluency is not evidence: an answer "feeling solid" is precisely the signal that masks error, for
+the agent and for the reader. The stop condition is an external check, never an internal sense of
+certainty.
+
+## Core Workflow
+
+1. **Enumerate.** On load-bearing decisions — task approach, root-cause conclusion, anything
+   justifying a consequential action — name at least the **two most plausible candidates** and the
+   *checkable difference* that discriminates them. One candidate is not analysis; naming a second
+   forces discrimination and usually points directly at the check that settles it. The runner-up
+   must be the most plausible alternative, not a strawman, and the discriminator must be checkable,
+   not vibes.
+2. **Route.** Pick verification by the dials:
+   - Very low confidence → prune without ceremony.
+   - Default ground truth is the **code** — authoritative for what *is*, and usually the cheapest
+     check available.
+   - **Docs and skills** verify intent and convention — why something is shaped the way it is.
+   - **Tests** verify behavior.
+   - High stakes → the strongest feasible check, regardless of felt confidence.
+3. **Prune on evidence** — never on first impression, and never on bare assertion, whether the
+   agent's own or the human's.
+4. **Abstain explicitly** when the required confidence is unreachable with the available checks:
+   - Low stakes → proceed, with the assumption explicitly marked:
+     "assuming X — couldn't verify; Y would settle it."
+   - High stakes → stop and surface what was checked, what remains unknown, and what would settle
+     it; the decision goes to the user.
+
+## Human Claims
+
+- A human interaction is **high-stakes by default** — it steers everything downstream. When the
+  user asserts or challenges something, re-verify **both** the user's claim and the agent's own
+  prior position against ground truth, rather than flipping (sycophancy) or digging in
+  (overconfidence).
+- **Categorical anti-flip rule:** never update a stated position on assertion alone — only on
+  evidence. For trivial claims the evidence is a two-second code glance; the trigger is
+  non-negotiable, the cost stays proportionate.
+- **Point-of-consequence verification:** a casual low-stakes remark may be provisionally accepted
+  and marked unverified; the moment it starts justifying a consequential action, its stakes have
+  risen and it gets verified then.
+
+## Defaults
+
+- Code first; docs and skills for intent; tests for behavior.
+- The enumeration floor binds on load-bearing decisions only; trivial, reversible micro-decisions
+  are exempt.
+- When stating a conclusion, say what verified it; when stating an assumption, mark it as one.
+- Escalating verification is not the same as asking permission: a confirm-with-the-user rule
+  governs *acting*; this policy governs *believing*. Verify the claim before presenting the
+  action for confirmation.
+
+## Gotchas
+
+- **Calibration is not maximal hedging.** Reflexive "I might be wrong" on verified claims is as
+  uncalibrated as false certainty, and it trains the reader to ignore uncertainty markers —
+  destroying their value for the claims that genuinely need them.
+- **Evidence-seeking is not contrarianism.** Pushing back on the user without verifying swaps
+  sycophancy for a different bias. The goal is to change what counts as evidence, not to disagree
+  by default.
+- **Keep the cheap path cheap.** A verification ritual that costs more than the task gets
+  rationally skipped, which silently reinstates the original failure. Scope the ceremony to
+  load-bearing decisions.
+- **Stakes recognition is itself a judgment.** Prefer the concrete trigger list (delete, overwrite,
+  push, publish, migrate, send, post a PR or Jira comment) over a felt sense of risk when
+  classifying an action.
+- **Enumeration can be gamed.** Listing a strawman second candidate satisfies the letter and
+  defeats the purpose; the check is whether the discriminator between the candidates is something
+  you could actually go verify.
+
+## Validation
+
+- Before committing to an approach or root cause: were at least two plausible candidates named,
+  with a checkable discriminator?
+- Before a destructive, irreversible, or outward-facing action: was the justifying claim verified
+  by the strongest feasible check, not just felt confidence?
+- After a user challenge: were both positions re-verified in ground truth before the position
+  changed or was defended?
+- In the final answer: does stated confidence match the evidence actually gathered, and are
+  unverified assumptions explicitly marked?
+
+## Examples
+
+Task-approach framing:
+
+```md
+Two plausible approaches to add the export format: (a) extend the existing serializer,
+(b) add a dedicated formatter module. Discriminator: does the serializer already branch on
+format anywhere? Checked the code — it does, twice. Extending it (a) follows the existing
+seam; picking (b) would duplicate dispatch. Going with (a).
+```
+
+Bug-cause framing with a user challenge:
+
+```md
+User: "The tests fail because of the new fixture, right?"
+Two plausible causes: (a) the changed fixture, (b) dependency drift after the rebase.
+Discriminator: a clean dependency sync. Ran it — failures persist, and the failing
+assertions all read the new fixture's fields. Evidence supports (a), agreeing with you —
+confirmed by the diff, not by the assertion.
+```
+
+Abstention framing:
+
+```md
+Whether the third-party webhook retries on 503 isn't documented and can't be tested from
+here. Low-stakes path: proceeding with idempotent handling, marked as an assumption.
+High-stakes path (if retries could double-charge): stopping — checked the vendor docs and
+SDK source; retry policy remains unknown; a sandbox test against their API would settle it.
+```

--- a/.claude/skills/ref-md-dev-coding-patterns/SKILL.md
+++ b/.claude/skills/ref-md-dev-coding-patterns/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: ref-md-dev-coding-patterns
+description: >-
+  Cross-cutting coding conventions used across Mindoktor repos
+  (TypeScript / React / React Native, Python, and Go where relevant).
+  Use when: writing or reviewing code, naming variables or functions,
+  deciding whether to add a comment, cleaning up code you touched,
+  or organizing files and functions, or deciding whether to imitate the
+  surrounding code or follow a documented convention. Covers naming, comments,
+  Boy Scout Rule, documented-convention-beats-local-imitation, code organization,
+  composition over inheritance, and nullish-vs-empty defaults.
+metadata:
+  author: mindoktor
+  version: "1.11"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "dev"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "5774e76"
+  shareable-skills.vendored-time: "2026-07-16"
+---
+
+# Mindoktor Coding Patterns
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+Cross-cutting conventions that apply to code across Mindoktor repos — TypeScript, React, React Native, Python, Go, shell scripts, and configuration files.
+
+These rules are language-agnostic. For TypeScript-specific guidance (types, imports, low-hanging fruit), load `ref-md-js-typescript`; for Python-specific guidance (Pyright strict typing, structure, testing), load `ref-md-py-python`.
+
+## Scope
+
+Covers how to **write and shape code you are editing**: naming, comments, the Boy Scout Rule, code organization, composition over inheritance, and nullish-vs-empty defaults.
+
+Does **not** cover:
+
+- Git, commits, pull requests, reviews, CI → the `ref-md-dev-workflow` skill
+- Language- or framework-specific deep-dives → `ref-md-js-typescript` and the other `ref-md-js-*` skills
+
+## Quick Routing (Progressive Discovery)
+
+| If your task is...                           | Read first                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------------- |
+| Improve naming or function readability       | [Naming](#naming)                                                         |
+| Decide whether to add/remove a comment       | [Comments](#comments)                                                     |
+| Apply cleanup while already editing a file   | [Boy Scout Rule](#boy-scout-rule)                                         |
+| Refactor structure of a long/complex file    | [Code Organization](#code-organization)                                   |
+| Share behavior without a class hierarchy     | [Composition over Inheritance](#composition-over-inheritance)             |
+| Handle absent values without masking bugs    | [Nullish Values over Empty Defaults](#nullish-values-over-empty-defaults) |
+| TypeScript types, imports, low-hanging fruit | `ref-md-js-typescript`                                                    |
+| Maintain `cSpell.words` in any repo          | [Spell Checking](#spell-checking-cspellwords)                             |
+
+## Recommended Read Order
+
+1. Apply [Naming](#naming) and [Comments](#comments) rules first (always-on baseline).
+2. Apply [Boy Scout Rule](#boy-scout-rule) and [Code Organization](#code-organization) when touching existing code.
+3. Use [Nullish Values over Empty Defaults](#nullish-values-over-empty-defaults) for data modeling and API boundary decisions.
+
+| Topic                                               | Read                                                           |
+| --------------------------------------------------- | -------------------------------------------------------------- |
+| Nullish values vs. empty defaults (TypeScript + Go) | [`references/nullish-values.md`](references/nullish-values.md) |
+
+## Naming
+
+| What                                         | Why                                                                                                            | When                                                                                                                                                   |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Prefer clear, complete names                 | Readable code reduces cognitive load for reviewers                                                             | Every variable, function, type, and file                                                                                                               |
+| Abbreviate only universally understood terms | Uncommon abbreviations force readers to guess                                                                  | `err`, `ctx`, `req`, `res`, `id`, `db` are fine                                                                                                        |
+| Name booleans as questions                   | `isActive` reads naturally in conditionals                                                                     | Boolean variables and function return values                                                                                                           |
+| Name functions after what they do            | Action verbs make call sites self-documenting                                                                  | All functions and methods                                                                                                                              |
+| Use camelCase for JS/TS filenames            | Dashed filenames (`path-utils.mjs`) are inconsistent with symbol naming and make utility files noisier to scan | JavaScript / TypeScript files and scripts — except React component files, which are PascalCase after the component (`CaseActionList.tsx`)              |
+| Use neutral names for meaningless values     | `t, u` imply a meaning that isn't there; `a, b` honestly signal position-only                                  | Comparator/positional params and throwaway locals with no domain meaning (conversely, name a real value for what it is: `patchVersion`, not `version`) |
+| Reserve plural names for collections         | A plural (`cases`, `authors`) reads as a list/slice/array; a single value named plural misleads the reader     | Any single value — name a dependency or collaborator by its role (`caseGetter`, `userGetter`), not a plural noun                                       |
+| Avoid shadowing an outer name                | A reused name hides the enclosing binding and invites referring to the wrong one                               | Any nested scope reusing an enclosing parameter/variable name — rename the inner (not consistently lint-enforced; apply deliberately)                  |
+
+## Comments
+
+A good comment **ages like wine, not milk**: it stays true long after the PR is merged. Before writing one, ask whether it will still be accurate and useful in a year — if it only holds for the length of the review, it belongs in the PR description, not the code.
+
+| What                                                        | Why                                                                                                                                 | When                                                                       |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Code should explain itself                                  | Comments that restate logic drift from the code and mislead                                                                         | Always — default to no comment                                             |
+| Reserve comments for business reasons                       | "Why" is not visible in the code; "what" usually is                                                                                 | Regulatory rules, domain quirks, workarounds                               |
+| Keep comments crisp                                         | A long-winded comment gets skimmed past; a dense one gets read                                                                      | Every comment — if one line says it, use one line                          |
+| Write for the next reader, not the reviewer                 | Review-scoped notes ("changed per feedback", "TODO before merge", "replaces the old approach") are stale the moment the PR merges   | Keep review context in the PR thread; keep only the durable "why" in code  |
+| Mind how it reads, not just what it states                  | A true fact in review-relative or apologetic terms ("hacky", "temporary", "for now", "we used to") reads as wrong even when correct | Phrase every comment as a standing statement about the code as it is today |
+| Do not add comments to code you did not change              | Unsolicited comment passes create noise in PRs                                                                                      | Unless fixing a factual error in the comment                               |
+| When adding JSDoc to a throwing function, include `@throws` | Callers should see exceptional behavior at the call site instead of discovering it from implementation details                      | JavaScript / TypeScript functions documented with JSDoc                    |
+
+## Boy Scout Rule
+
+Leave code better than you found it — scoped to the same file or small, closely related files (e.g., a component and its direct consumers).
+
+| What                                                   | Why                                                  | When                                                                       |
+| ------------------------------------------------------ | ---------------------------------------------------- | -------------------------------------------------------------------------- |
+| Fix lint warnings in files you are already editing     | Keeps the codebase from accumulating low-level debt  | Every change — not optional                                                |
+| Add or update unit tests for testable behavior changes | Prevents regressions and keeps future refactors safe | When business logic, parsing, transformations, or command behavior changes |
+| Fix outdated patterns in the same file                 | Prevents "broken windows" effect                     | When the fix is small and obvious                                          |
+| Do not cascade into unrelated parts of the codebase    | Boy Scout scope must stay reviewable                 | Always — if the cleanup needs its own PR, stop                             |
+
+For TypeScript-specific low-hanging fruit (braceless `if`, `any`, non-null assertions, deep relative imports, barrels, etc.), see the `low-hanging-fruit` reference in `ref-md-js-typescript`.
+
+## Documented Convention Beats Local Imitation
+
+Agents are told to write code that reads like its neighbors — and that instinct is usually right. But it is **conditional, not primary**: the documented convention (the matching `ref-md-*` skill) is the source of truth, and imitation is only valid **when the surrounding code already conforms to it**. Imitating a stale neighbor propagates the drift the skills exist to prevent — and CI often will not catch it (many conventions, e.g. the `React.FC<Props>` template, are not lint-enforced).
+
+| What                                                              | Why                                                                                                      | When                                                                                   |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Load the matching stack skill **before** writing code in its area | The skill is the source of truth; deciding a self-contained feature "doesn't need it" is the usual miss  | Before writing a component, hook, query, style block, etc. — not after review flags it |
+| Match neighbors **only if** they conform to the skill             | A folder can hold old and new patterns side by side; the nearest structural sibling may be the stale one | Every time you model new code on existing code                                         |
+| When skill and neighbor disagree, follow the **skill**            | The documented pattern is the default; a divergent neighbor is not a template                            | Any disagreement between a loaded skill and the surrounding code                       |
+| Treat the divergent neighbor as a **Boy-Scout candidate**         | It is drift to fix (in scope), not a convention to copy                                                  | When you notice a neighbor diverges — see [Boy Scout Rule](#boy-scout-rule)            |
+
+## Code Organization
+
+| What                                                     | Why                                                                                                                                                           | When                                                                                                                                                                                                            |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep functions focused on one responsibility             | Smaller functions are easier to test, read, and name                                                                                                          | Always — extract when a function does two unrelated things                                                                                                                                                      |
+| Extract when logic is reused, not preemptively           | Premature abstraction creates indirection without value                                                                                                       | Only when the same logic appears in 2+ places                                                                                                                                                                   |
+| Don't dismiss dedup on signature mismatch alone          | Two functions doing the same thing with different signatures are still duplicates — a thin adapter (split a string, wrap in an object) bridges them trivially | Always — read both implementations before deciding                                                                                                                                                              |
+| Avoid deeply nested conditionals                         | Flat code is easier to follow                                                                                                                                 | Use early returns or guard clauses to flatten                                                                                                                                                                   |
+| Keep files under ~300 lines                              | Long files signal mixed responsibilities                                                                                                                      | Split when a file covers multiple unrelated concerns                                                                                                                                                            |
+| Delete code that doesn't earn its place                  | Pass-through wrappers, redundant guards, and speculative (YAGNI) code add surface without value                                                               | Prefer removing over keeping when something only forwards a call, re-checks an already-guaranteed invariant, or exists "just in case"                                                                           |
+| Split a utils/helpers file that mixes unrelated concerns | A grab-bag collects unrelated responsibilities and resists discovery                                                                                          | A `utils`/`helpers` file accumulates unrelated functions — split by concern (e.g. `access`, `params`). A feature-scoped `utils` of cohesive helpers is fine; the smell is mixing unrelated things, not the name |
+
+## Composition over Inheritance
+
+Build behavior by assembling small, independent pieces; reach for inheritance (`extends`, deep class hierarchies) only when a framework genuinely requires it. Inheritance couples a subtype to a base's internals and resists change, whereas composed pieces stay testable and recombine freely.
+
+The Pulse component library (`mindoktor-app/packages/pulse`) is the reference example. Three patterns recur:
+
+| Pattern                      | What it looks like                                                                      | Pulse example                                                                     |
+| ---------------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Compound components          | A parent exposes sub-components arranged as `children`, not configured by many props    | `BottomSheet` + `BottomSheetHeader` / `BottomSheetContent` / `BottomSheetActions` |
+| Wrap a primitive             | A higher-level component renders a configured lower-level one — it does not subclass it | `Card` renders a styled `Stack`                                                   |
+| Extract behavior into a hook | Shared logic lives in a hook components consume, not in a base class                    | `PillGroup` gets keyboard navigation from `useRadioGroupKeyboard`                 |
+
+`Card` composing `Stack` rather than extending it:
+
+```tsx
+const Card: React.FC<CardProps> = ({ children, padding = 1, ...props }) => (
+  <Stack padding={padding} borderRadius={props.borderRadius ?? 0.5} shadowVariant="default" {...props}>
+    <Stack>{children}</Stack>
+  </Stack>
+);
+```
+
+The principle is language-agnostic: in Go, embed and compose small interfaces and structs instead of deep type hierarchies; in Python, prefer small collaborators and `Protocol`s over inheritance chains.
+
+## Nullish Values over Empty Defaults
+
+Use `null` / `undefined` (TypeScript) or `nil` + pointer types (Go) to represent absent values — not empty strings, zero, or sentinel values. Empty defaults hide missing data from the type system. See [`references/nullish-values.md`](references/nullish-values.md) for the full rationale, acceptable exceptions, and language-specific implications.
+
+## Spell Checking (`cSpell.words`)
+
+When adding entries to `cSpell.words` in any repo's `.vscode/settings.json`:
+
+| What                                     | Why                                                                                  | When                                                                                             |
+| ---------------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| Keep the array in **alphabetical order** | Prevents duplicates and keeps diffs reviewable                                       | Every time an entry is added or removed                                                          |
+| Use the **lowercase form**               | Library names, tool names, and domain terms are written lowercase in code            | Always — uppercase only for words that are genuinely uppercase in the codebase (e.g. `EFRIKORT`) |
+| Add only **meaningful technical terms**  | Misspellings and one-off abbreviations pollute the list and defeat the spell checker | Library names, tool names, domain vocabulary, and well-known abbreviations                       |
+
+**Low-hanging fruit:** when you encounter a `cSpell.words` array that is unsorted, contains non-lowercase words, or is missing a technical term you know belongs there — fix it as a Boy Scout pass. No dedicated PR needed; fold it into the commit that touched the related file.
+
+## Related Skills
+
+| Skill                  | When to load                                                           |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `ref-md-js-typescript` | TypeScript-specific conventions, types, and low-hanging fruit          |
+| `ref-md-js-tests`      | Test structure, naming, date-lib mocking patterns for JS/TS code       |
+| `ref-md-py-python`     | Python-specific conventions: Pyright strict typing, structure, testing |

--- a/.claude/skills/ref-md-dev-coding-patterns/references/nullish-values.md
+++ b/.claude/skills/ref-md-dev-coding-patterns/references/nullish-values.md
@@ -1,0 +1,40 @@
+# Nullish Values over Empty Defaults
+
+Use `null` / `undefined` (TypeScript) or `nil` + pointer types (Go) to represent absent values — not empty strings (`""`), zero (`0`), or sentinel values (`-1`). Empty defaults hide missing data from the type system and push detection to runtime; nullish types make the compiler catch it.
+
+## Why
+
+```ts
+// With empty default — compiles, fails silently at runtime
+const handleName = (name: string) => { ... };
+const userName: string = dataIsMissing ? '' : 'John Doe';
+handleName(userName); // TypeScript sees nothing wrong
+
+// With nullish — compiler forces handling
+const userName: string | undefined = dataIsMissing ? undefined : 'John Doe';
+handleName(userName); // TS error: string | undefined is not assignable to string
+```
+
+The value of this scales with codebase size: every function downstream of the empty default silently accepts invalid data, while nullish propagates the constraint through the type system.
+
+## When empty values are acceptable
+
+Use empty defaults when the empty value is **semantically meaningful**, not a stand-in for "missing":
+
+| Use case                   | Value   | Reason                                               |
+| -------------------------- | ------- | ---------------------------------------------------- |
+| Text input initial state   | `''`    | The user has entered nothing yet — that is the value |
+| Counter starting from zero | `0`     | Zero is a valid count                                |
+| Boolean flag default       | `false` | The flag is explicitly off                           |
+
+The test: if the consumer needs to distinguish "absent" from "empty", use nullish. If they don't, an empty default is fine.
+
+## TypeScript implications
+
+The TypeScript mechanics — parsing to `null`, the empty-value helper, `strict-boolean-expressions`, Zod `.nullable()` / `.optional()`, and `assertUnreachable` — live in the `ref-md-js-typescript` skill (§ Representing Absent Values, plus its low-hanging-fruit). This file keeps only the cross-language principle and the Go side.
+
+## Go implications
+
+- Use `omitempty` / `omitzero` JSON struct tags when a field being absent is distinct from the zero value. If the zero value means "not provided", the field should be a pointer type with `omitempty` so the frontend receives `null` (or the field is omitted) rather than `""` or `0`.
+- Example: a patient's middle name that was never entered should be `*string` with `omitempty`, not `string` defaulting to `""`.
+- Conversely, if `0` or `""` is a valid domain value (e.g., a counter, a status code), keep the value type and do not use `omitempty`.

--- a/.claude/skills/ref-md-dev-eslint-config/SKILL.md
+++ b/.claude/skills/ref-md-dev-eslint-config/SKILL.md
@@ -57,9 +57,25 @@ Entry: [`src/index.ts`](../../../src/index.ts) exports a `configs` object with t
 - **`no-unused-vars` is intentionally handled by `unused-imports`**, not typescript-eslint — `recommended.ts` turns the tseslint rule off and delegates. Don't "restore" the tseslint rule.
 - **`dist` is gitignored** and only committed onto a version branch at release time. Do not commit `dist/` to `develop`.
 
+## Verifying a Change Against a Consumer
+
+A config change has no runtime surface of its own; its only observable effect is the lint output it produces in a consumer. `yarn lint` against `examples/` is a quick first check, but it does not prove what the change does to real project code. For anything beyond a trivial edit, verify against a real consumer in an **isolated, branched worktree** so you can see the exact before/after and confirm nothing changed that you did not intend.
+
+Use whichever consumer repo is cloned locally. Preferred is **CLINIC_APP** (in the `mindoktor` repo), which depends on this package by git URL and is simple to repoint; the `mindoktor-app` repo is the alternative. Locate the checkout rather than assuming a path (it is a working directory in this session), and always work in a **worktree**, never the consumer's main checkout, so its normal state is untouched.
+
+| Step | What                                                                                                 | Why                                                                          |
+| ---- | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| 1    | In the consumer repo, add a throwaway worktree on a new branch off its default branch                | Keeps the consumer's main checkout and branches clean                        |
+| 2    | Run the consumer's lint first and capture the baseline output                                        | The baseline is what you diff against; skip it and "no change" is unprovable |
+| 3    | Point the consumer's `@mindoktor/eslint-config` dependency at your change, reinstall, run lint again | This is what surfaces the real effect on real code                           |
+| 4    | Diff the two lint runs                                                                               | No diff confirms an unintended-change-free edit; a diff must match intent    |
+| 5    | Remove the worktree when done                                                                        | No leftover branches or installs                                             |
+
+**Getting your change into the consumer.** The dependency is a git URL (CLINIC_APP pins `mindoktor/eslint-config#^2.2.1`), so repoint it at your branch: `@mindoktor/eslint-config@mindoktor/eslint-config#<your-branch>`, then reinstall. **Caveat (see Gotchas):** `dist/` is only built onto a *version* branch at release time, not onto feature branches, so a plain feature branch has no `dist/` to resolve. Either test against a released version branch cut from your change, or build `dist/` locally (`yarn cleanbuild`) and point the consumer at your local build. Confirm the consumer actually picked up your version before trusting the lint diff.
+
 ## Standard Commands
 
-`yarn lint` · `yarn lint:fix` · `yarn build` (tsc → `dist/`) · `yarn typecheck` · `yarn cleanbuild` · `yarn release`. A config change has no runtime surface of its own — verify it by running `yarn lint` against `examples/` or a consumer repo and confirming the intended rule output.
+`yarn lint` · `yarn lint:fix` · `yarn build` (tsc → `dist/`) · `yarn typecheck` · `yarn cleanbuild` · `yarn release`. For how to verify a change's real effect, see *Verifying a Change Against a Consumer* above.
 
 ## Related Skills
 

--- a/.claude/skills/ref-md-dev-eslint-config/SKILL.md
+++ b/.claude/skills/ref-md-dev-eslint-config/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: ref-md-dev-eslint-config
+description: >-
+  Work in @mindoktor/eslint-config, the shared ESLint flat config consumed by
+  Mindoktor's TypeScript projects. Use when: cutting or reasoning about a release,
+  running release-it, changing an exported config or a lint rule, adding a config
+  export, or judging the blast radius of a rule change across consumers.
+  Covers the non-standard release model (git-branch-per-version, no npm publish),
+  the exported configs, the load-order gotcha, and consumer install.
+metadata:
+  author: mindoktor
+  version: "1.0"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/eslint-config"
+  shareable-skills.domain: "dev"
+  shareable-skills.visibility: "repo-local"
+  shareable-skills.reason: "encodes this repo's bespoke release-it flow and config layout"
+---
+
+# eslint-config (repo)
+
+The repo-specific knowledge for `@mindoktor/eslint-config`. Generic TypeScript conventions live in `ref-md-js-typescript`; cross-cutting code quality in `ref-md-dev-coding-patterns`. This skill holds only what those can't: the release flow and the config's public surface.
+
+## Release Model — read before cutting a release
+
+The release is **not** a standard npm publish. `release-it` (config in [`.release-it.ts`](../../../.release-it.ts), run via `yarn release`) does something bespoke:
+
+| Fact                                                                                                   | Why it matters                                                                                      |
+| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `npm.publish: false`, `git.tag: false`                                                                 | Nothing is pushed to the npm registry and **no version tag** is created. Don't expect either.       |
+| A "release" is a **git branch named after the version** (`git switch -C ${version}`), pushed to origin | The version branch (e.g. `2.2.1`) **is** the published artifact.                                    |
+| Built `dist/` is **force-added** into that branch (`git add dist -f`)                                  | `dist` is gitignored (built by `yarn cleanbuild` in `before:release`); the force-add is deliberate. |
+| `requireBranch: 'develop'`, `requireCleanWorkingDir: true`                                             | Release only runs from a clean `develop`. `before:init` runs `git pull`, `yarn`, lint, typecheck.   |
+| `after:release` switches back to `develop`                                                             | You end on `develop`, with the version branch left on origin.                                       |
+
+**Consumers install by git URL, not from the registry** — `yarn add -D @mindoktor/eslint-config@mindoktor/eslint-config#<version>` resolves to that version branch (semver-named branches get semver treatment). See the README.
+
+Because publish is disabled, `package.json`'s `"files"` allowlist does not gate an actual npm publish today — but it stays the correct hygiene (and would gate a publish if one is ever enabled), which is why non-`dist` files like `.claude/` are excluded from it.
+
+## Config Surface
+
+Entry: [`src/index.ts`](../../../src/index.ts) exports a `configs` object with three named configs, plus a `default` (`stylistic` + `recommended`):
+
+| Export                     | Source                                                                        | What                                                                        |
+| -------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `configs.recommended`      | [`src/configs/recommended.ts`](../../../src/configs/recommended.ts)           | ESLint + typescript-eslint **strict** type-checked, imports, unused-imports |
+| `configs.reactRecommended` | [`src/configs/reactRecommended.ts`](../../../src/configs/reactRecommended.ts) | `recommended` + `eslint-plugin-react` + react-hooks                         |
+| `configs.stylistic`        | [`src/configs/stylistic.ts`](../../../src/configs/stylistic.ts)               | Prettier via `eslint-plugin-prettier` (single quotes, TS parser)            |
+
+- `eslint-plugin-react` and `eslint-plugin-react-hooks` are **optional peer dependencies** — `reactRecommended` only works when the consumer installs them.
+- This package is pure config: no React/MUI/Redux/Next/Go/DB runtime code lives here, even though it *emits* React lint rules.
+
+## Gotchas
+
+- **Extends order is load-bearing.** Consumers must list `stylistic` before `recommended` (`extends: [configs.stylistic, configs.recommended]`) — a wrong order silently drops rules. This was a real bug fixed in [#12](https://github.com/mindoktor/eslint-config/pull/12) ("Change lint extends order to fix rules not being applied"). Keep the README examples in this order.
+- **A rule change here propagates to every consumer** (patient-app, clinic-app, and others) on their next version bump. Weigh any rule addition or severity change against that blast radius; prefer a narrowly-scoped, well-justified change and note it in the PR.
+- **`no-unused-vars` is intentionally handled by `unused-imports`**, not typescript-eslint — `recommended.ts` turns the tseslint rule off and delegates. Don't "restore" the tseslint rule.
+- **`dist` is gitignored** and only committed onto a version branch at release time. Do not commit `dist/` to `develop`.
+
+## Standard Commands
+
+`yarn lint` · `yarn lint:fix` · `yarn build` (tsc → `dist/`) · `yarn typecheck` · `yarn cleanbuild` · `yarn release`. A config change has no runtime surface of its own — verify it by running `yarn lint` against `examples/` or a consumer repo and confirming the intended rule output.
+
+## Related Skills
+
+| Skill                        | When to load                                          |
+| ---------------------------- | ----------------------------------------------------- |
+| `ref-md-js-typescript`       | TypeScript conventions when editing the config source |
+| `ref-md-dev-coding-patterns` | Cross-cutting code quality                            |

--- a/.claude/skills/ref-md-js-tests/SKILL.md
+++ b/.claude/skills/ref-md-js-tests/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ref-md-js-tests
+description: >-
+  Testing conventions for Mindoktor TypeScript/JavaScript code — unit and
+  integration / module-level tests with Jest.
+  Use when: adding test coverage for pure functions, hooks, modules, or
+  integration seams, updating tests after behavior changes, naming test files,
+  or introducing mocks in Jest-based tests.
+  Covers test placement, naming patterns, Jest mocking, fake-timer time mocking,
+  per-library date mocking (dayjs for clinic and legacy patient, date-fns for
+  patient-phoenix), hook testing, and maintenance rules. E2e (Playwright) lives in
+  mindoktor-testing; React component-render testing in `ref-md-js-react`.
+metadata:
+  author: mindoktor
+  version: "1.10"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "js"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+  shareable-skills.requires: "ref-md-js-typescript"
+  shareable-skills.suggests: "ref-md-js-react"
+---
+
+# JavaScript and TypeScript Tests
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+Use this skill for testing in Mindoktor JavaScript and TypeScript codebases — unit and integration / module-level tests with Jest.
+
+`ref-md-js-typescript` is required baseline context. This skill focuses on testing patterns and does not repeat TypeScript fundamentals.
+
+## Scope
+
+Covers JS/TS testing conventions — placement, naming, Jest mocking, time mocking, and per-library date mocking (`dayjs` for clinic and legacy patient, `date-fns` for patient-phoenix) — for unit and integration / module-level tests. **Not** here: end-to-end tests (Playwright), in the `mindoktor-testing` repo; React component-render testing, in `ref-md-js-react`. For TypeScript see [`ref-md-js-typescript`](../ref-md-js-typescript/SKILL.md); quality expectations `ref-md-dev-coding-patterns`.
+
+## Source Basis
+
+This guidance draws from both Mindoktor frontends — patient-app (`packages/apps/patient/phoenix/` in `mindoktor-app`) and clinic-app. They share Jest conventions but differ in date library (patient: `date-fns`, clinic: `dayjs`), so library-specific date-test setup is deferred to each app's own skill.
+
+- Tooling: Jest (patient-app: `test` and `test:ci` scripts; clinic-app: `test` only)
+- File patterns: `*.test.ts` / `*.test.tsx` are the standard; `*.spec.*` is a legacy minority, and clinic-app carries older dash-variant `*-test.ts(x)` files (see [`references/test-vs-spec-naming.md`](references/test-vs-spec-naming.md))
+- Placement: co-located next to implementation files in most packages; clinic-app predominantly uses sibling `__tests__/` folders — match the folder's existing convention
+- Mocking: `jest.mock(...)` and `jest.mocked(...)` for dependency seams
+
+## Routing Table
+
+| Task                                                              | Read                                                                     |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Writing and maintaining tests                                     | [`references/patterns.md`](references/patterns.md)                       |
+| Mocking dates with dayjs (clinic + legacy patient)                | [`references/dayjs.md`](references/dayjs.md)                             |
+| Mocking dates with date-fns (patient-phoenix)                     | [`references/date-fns.md`](references/date-fns.md)                       |
+| Naming test files (`.test` vs `.spec`) and the evidence behind it | [`references/test-vs-spec-naming.md`](references/test-vs-spec-naming.md) |
+
+## Quick Rules
+
+- Add or update tests whenever behavior changes in testable code.
+- Keep test files near the module under test — flat or in a `__tests__/` subdirectory per the app's convention.
+- Name new test files `*.test.ts` / `*.test.tsx` — the measured standard in both repos; use `*.spec.*` only when extending a folder that already uses it ([evidence](references/test-vs-spec-naming.md)).
+- Mock dependencies at module boundaries (`jest.mock`), not internal implementation details.
+- Assert behavior and outputs, not private implementation structure.
+
+## Related Skills
+
+| Skill                                                      | When to load                                               |
+| ---------------------------------------------------------- | ---------------------------------------------------------- |
+| [`ref-md-js-typescript`](../ref-md-js-typescript/SKILL.md) | Type safety and strictness rules for test and source files |
+| `ref-md-js-react`                                          | React-specific hook/component testing context              |
+| `ref-md-dev-coding-patterns`                               | Cross-cutting quality and Boy Scout expectations           |

--- a/.claude/skills/ref-md-js-tests/references/date-fns.md
+++ b/.claude/skills/ref-md-js-tests/references/date-fns.md
@@ -1,0 +1,13 @@
+# Mocking dates in tests — date-fns (patient-phoenix)
+
+Patient-phoenix (`packages/apps/patient/phoenix/`) uses `date-fns`; legacy patient code and clinic-app use `dayjs` (see [`dayjs.md`](dayjs.md)). `date-fns` functions are **pure** and take an explicit `Date` argument, so most date logic needs no mocking — pass a fixed date:
+
+```ts
+import { format } from 'date-fns';
+
+expect(format(new Date('2024-06-15T12:00:00Z'), 'yyyy-MM-dd')).toBe('2024-06-15');
+```
+
+- **Do not** `jest.mock('date-fns')` — mock whatever *produces* the date (or the clock), not the pure formatter.
+- When the code under test reads the system clock itself (`new Date()`, `Date.now()`), pin it with fake timers — see [Mocking Time](patterns.md#mocking-time). `date-fns` then reads the controlled clock with no extra setup.
+- Import named functions (`import { addDays } from 'date-fns'`) for tree-shaking. date-fns has no plugin-registration step (unlike dayjs).

--- a/.claude/skills/ref-md-js-tests/references/dayjs.md
+++ b/.claude/skills/ref-md-js-tests/references/dayjs.md
@@ -1,0 +1,16 @@
+# Mocking dates in tests — dayjs (clinic-app + legacy patient)
+
+`dayjs` is used in clinic-app and in **legacy patient** code (under `packages/apps/patient/legacy/`); patient-phoenix uses `date-fns` instead (see [`date-fns.md`](date-fns.md)). For pinning the clock, see [Mocking Time](patterns.md#mocking-time): dayjs reads the system clock, so `jest.useFakeTimers().setSystemTime(...)` controls it — there is no dayjs-specific *time* mock to add.
+
+## Plugins are not auto-registered in isolated tests
+
+The app registers dayjs plugins once at startup, but an isolated test file does not run that setup. Extend the plugins the code under test needs, per test file:
+
+```ts
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+```
+
+A missing plugin shows up only in the test, as a runtime error like `dayjs(...).utc is not a function`. Add an `extend` call for each plugin the tested code relies on.

--- a/.claude/skills/ref-md-js-tests/references/patterns.md
+++ b/.claude/skills/ref-md-js-tests/references/patterns.md
@@ -1,0 +1,118 @@
+# Unit Test Patterns
+
+## File Naming and Placement
+
+- Co-locate tests near the code under test. The exact layout varies by app — flat alongside the source, or in a `__tests__/` subdirectory — so follow the convention the folder already uses.
+- Default to `*.test.ts` / `*.test.tsx` — the measured standard ([why](test-vs-spec-naming.md)).
+- Keep existing `*.spec.ts` naming only when a folder already uses it (mostly legacy code).
+
+Examples — the two layouts, so neither reads as universal:
+
+**Flat co-location** (patient-phoenix, from `mindoktor-app` — paths relative to `packages/apps/patient/phoenix/`):
+
+- `auth/functions/tokenUtils.test.ts`
+- `booking/hooks/useOpenBookingSession.test.ts`
+- `messaging/components/Composer/MediaPreview/utils.spec.ts`
+
+**`__tests__/` subdirectory** (clinic-app, from `mindoktor/CLINIC_APP` — paths relative to `src/`; this is clinic's dominant layout):
+
+- `api/dashboard/__tests__/useCasesClosedVnext.test.ts`
+- `api/nll/__tests__/schemas.test.ts`
+- `common/utils/__tests__/displaySex-test.ts` (older dash-variant name)
+
+> **Per-app test setup** — path-alias config, run commands, and any enforced placement (e.g. a required `__tests__/` subdirectory) — lives in the skill named after the app you're working in (its hub skill, typically a `references/testing.md`). This file is the cross-app baseline.
+
+## Baseline Structure
+
+Use a clear `describe` + `it` structure:
+
+```ts
+describe('decodeTokenClaims', () => {
+  it('returns undefined for an empty string', () => {
+    expect(decodeTokenClaims('')).toBeUndefined();
+  });
+});
+```
+
+Keep test names behavior-focused: what happens and under which input/condition.
+
+## Mocking Strategy
+
+- Mock external dependencies with `jest.mock(...)`.
+- Use `jest.mocked(...)` for typed mocked values/functions.
+- Reset or clear mocks between test cases (`jest.clearAllMocks()`).
+
+```ts
+jest.mock('./useCreateBookingSessionMutator', () => ({
+  useCreateBookingSessionMutator: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+```
+
+## Mocking Time
+
+When the code under test reads "now" from the system clock, pin it with fake timers (recommended); always restore real timers in `afterAll`:
+
+```ts
+const NOW = new Date('2024-06-15T12:00:00Z');
+
+beforeAll(() => {
+  jest.useFakeTimers().setSystemTime(NOW);
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+```
+
+Reach for fake timers only when the code reads the clock itself. When a function instead **takes the date as an argument**, just pass a fixed `Date` — no fake timers needed, and it reads more clearly. Some parts of the codebase rely entirely on fixed date args and use no fake timers at all, so don't assume the fake-timer setup is already in place.
+
+## Date libraries and the fake clock
+
+Date libraries read the system clock, so the fake timer above covers code that reads "now". The two frontends use different libraries — see the per-library reference for setup details: [`dayjs`](dayjs.md) (clinic) and [`date-fns`](date-fns.md) (patient).
+
+## Testing Hooks
+
+Two approaches, depending on whether the package renders to the DOM and carries `@testing-library/react`:
+
+**With `@testing-library/react`** — for hooks that depend on TanStack Query, render them with `renderHook` inside a `QueryClientProvider` (disable retries so failures surface immediately):
+
+```ts
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: React.PropsWithChildren) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
+```
+
+**Without a renderer** — some packages have no `@testing-library/react` (a React Native app/package, or a util package). There, test a hook by **mocking its dependencies (e.g. `jest.mock('@tanstack/react-query')`) and calling it directly**, asserting on what it wires up — no `renderHook`. Which approach a package uses is per-app — see the skill named after your app.
+
+## What to Test
+
+Prioritize:
+
+1. Pure utility functions (input/output behavior)
+2. Hook orchestration logic (branching and side effects at boundaries)
+3. Parsing/validation/error handling paths
+
+Do not prioritize:
+
+- Snapshot-heavy tests for simple pure logic
+- Re-testing third-party library behavior
+- Assertions on private internals when public behavior already proves correctness
+
+## Maintenance Rules
+
+- If behavior changes, update tests in the same PR.
+- If a bug was fixed, add a regression test covering the bug path.
+- Keep fixtures minimal and local to the test file unless reused by multiple tests.

--- a/.claude/skills/ref-md-js-tests/references/test-vs-spec-naming.md
+++ b/.claude/skills/ref-md-js-tests/references/test-vs-spec-naming.md
@@ -1,0 +1,95 @@
+# Test File Naming: `.test` vs `.spec`
+
+**Convention: name new test files `*.test.ts` / `*.test.tsx`.** Use `*.spec.*`
+only when extending a folder that already uses it. This is not a style
+preference — it reflects the measured reality of the codebases.
+
+## The Evidence
+
+A file-naming survey of the two main repos (May 2026) shows `.test` is the
+dominant and current convention; `.spec` is a shrinking legacy minority.
+
+> **Snapshot, not live counts.** The figures below are the May 2026 survey;
+> exact numbers drift as tests are added (phoenix stands at ~14 `.test` / 3
+> `.spec` as of July 2026). It's the *ratio and trend* that matter, and they
+> hold — re-run the commands in [How to Reproduce](#how-to-reproduce-the-check)
+> for authoritative current figures.
+
+### mindoktor-app
+
+| Bucket                     | `.spec.*` | `.test.*` | Dominant |
+| -------------------------- | --------- | --------- | -------- |
+| phoenix (newer)            | 3         | 8         | `.test`  |
+| non-phoenix (incl. legacy) | 18        | 31        | `.test`  |
+| **Total**                  | **21**    | **39**    | `.test`  |
+
+Three findings refute the common assumptions about `.spec`:
+
+- **Not more common.** `.test` leads roughly 2:1 overall.
+- **Not newer.** The 25 most-recently-touched test files are *all* `.test`.
+  Current work (booking, auth, data-tracking, May 2026) is uniformly `.test`.
+- **Not the phoenix convention.** `.test` wins inside phoenix too (8 vs 3 at
+  survey time; 14 vs 3 as of July 2026).
+  Of the 21 `.spec` files, 10 sit in one old module —
+  `packages/apps/patient/legacy/apotekhjartat` — with the rest scattered
+  across `utils/validations`, `pulse`, and `localization`.
+
+### mindoktor
+
+| `.spec.*` | `.test.*` |
+| --------- | --------- |
+| 0         | 13        |
+
+Unanimous: zero `.spec` files, all tests are `.test` (CLINIC_APP). One wrinkle:
+older CLINIC_APP tests use a **dash variant** — `*-test.ts(x)` inside
+`__tests__/` folders (e.g. `__tests__/displaySex-test.ts`). Treat it like
+`.spec`: legacy, picked up via Jest's default `__tests__/` glob, fine to extend
+in place, but not for new test files outside those folders.
+
+### Conclusion
+
+`.test.{ts,tsx}` is the de facto and trending convention in both repos.
+`.spec` survives mainly in legacy pharmacy code and should not be used for new
+tests.
+
+## How to Reproduce the Check
+
+Run from the repo root. Excludes `node_modules`.
+
+### Count by pattern
+
+```bash
+echo -n ".spec: "; find . -path ./node_modules -prune -o -type f \
+  \( -name "*.spec.ts" -o -name "*.spec.tsx" -o -name "*.spec.js" -o -name "*.spec.jsx" \) \
+  -print | grep -vc node_modules
+echo -n ".test: "; find . -path ./node_modules -prune -o -type f \
+  \( -name "*.test.ts" -o -name "*.test.tsx" -o -name "*.test.js" -o -name "*.test.jsx" \) \
+  -print | grep -vc node_modules
+```
+
+### Where the `.spec` files cluster
+
+```bash
+find . -path ./node_modules -prune -o -type f -name "*.spec.*" -print \
+  | grep -v node_modules | sed -E 's|/[^/]+$||' | sort | uniq -c | sort -rn
+```
+
+### Recency — are `.spec` files newer? (rank by last commit date)
+
+```bash
+for f in $(find . -path ./node_modules -prune -o -type f \
+  \( -name "*.spec.*" -o -name "*.test.*" \) -print | grep -v node_modules); do
+  case "$f" in *.spec.*) kind=SPEC;; *) kind=test;; esac
+  echo "$(git log -1 --format=%cs -- "$f") $kind $f"
+done | sort -r | head -25
+```
+
+### Split by area (e.g. phoenix vs legacy)
+
+```bash
+echo -n "spec in phoenix: "; find . -path ./node_modules -prune -o -type f -name "*.spec.*" -print | grep -v node_modules | grep -ci phoenix
+echo -n "test in phoenix: "; find . -path ./node_modules -prune -o -type f -name "*.test.*" -print | grep -v node_modules | grep -ci phoenix
+```
+
+Re-run these if the convention is ever questioned — the numbers, not opinion,
+settle it.

--- a/.claude/skills/ref-md-js-typescript/SKILL.md
+++ b/.claude/skills/ref-md-js-typescript/SKILL.md
@@ -11,14 +11,14 @@ description: >-
   scripts (runtime type-stripping), and low-hanging fruit.
 metadata:
   author: mindoktor
-  version: "1.14"
+  version: "1.15"
   shareable-skills.owner-prefix: "md"
   shareable-skills.owner: "mindoktor/agentic-tools"
   shareable-skills.domain: "js"
   shareable-skills.visibility: "organization"
-  shareable-skills.vendored-sha: "f996033"
-  shareable-skills.vendored-time: "2026-07-13"
   shareable-skills.requires: "ref-md-dev-coding-patterns"
+  shareable-skills.vendored-sha: "a596295"
+  shareable-skills.vendored-time: "2026-07-19"
 ---
 
 # Mindoktor TypeScript Conventions

--- a/.claude/skills/ref-md-js-typescript/SKILL.md
+++ b/.claude/skills/ref-md-js-typescript/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: ref-md-js-typescript
+description: >-
+  TypeScript conventions used across Mindoktor repos.
+  Use when: writing TypeScript types, interfaces, lookup tables, type guards, null checks,
+  declaring functions as const arrow functions, applying opportunistic fixes to existing code,
+  taming `strict-boolean-expressions`, fixing deep relative imports, splitting type-only and
+  value imports, or choosing a file type for a new runnable Node script.
+  Covers strict mode rules, const arrow functions and their exceptions, Zod inference, import
+  hygiene, workspace package imports, representing absent values, `.mts`-first for new Node
+  scripts (runtime type-stripping), and low-hanging fruit.
+metadata:
+  author: mindoktor
+  version: "1.14"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "js"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+  shareable-skills.requires: "ref-md-dev-coding-patterns"
+---
+
+# Mindoktor TypeScript Conventions
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+Read this file when writing or reviewing TypeScript in a Mindoktor repo.
+
+This is the core language skill for both TypeScript and JavaScript work in Mindoktor repos. When working in `.js`/`.mjs`, use this skill first, then apply JavaScript-focused JSDoc guidance from [`references/low-hanging-fruit.md`](references/low-hanging-fruit.md).
+
+## Scope
+
+Covers TypeScript language conventions — types, strict mode, imports, Zod inference, and low-hanging fruit. For framework patterns see `ref-md-js-react`, `ref-md-js-mui`, `ref-md-js-redux`, `ref-md-js-tanstack-query`; for cross-cutting code quality see `ref-md-dev-coding-patterns`.
+
+## Routing Table
+
+| Task                                                           | Read                                                                 |
+| -------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Types, interfaces, lookup tables, Zod inference, null handling | [`references/types.md`](references/types.md)                         |
+| Opportunistic fixes when touching existing code                | [`references/low-hanging-fruit.md`](references/low-hanging-fruit.md) |
+| Cross-cutting naming, comments, code organization              | `ref-md-dev-coding-patterns`                                         |
+
+## Compiler Settings
+
+Mindoktor TypeScript projects share a `tsconfig-base.json` (or equivalent) that targets `strict: true` and `noImplicitAny: true`. Some apps mid-migration gate CI on a laxer config (clinic-app's `typecheck:ci` runs against `tsconfig-lax.json`) — write new code to the strict rules regardless. Never weaken them per-file with `@ts-ignore` or `as any` without a justification comment.
+
+Prefer constructs that are erased at compile time and produce no runtime output over constructs that generate JavaScript code.
+
+### `import type` for type-only imports
+
+Use `import type` whenever an import is used only in type annotations — it is erased at compile time and keeps module graphs clean. Choose the form by what the module brings in:
+
+- **Type-only** → statement form `import type { X } from '...'`.
+- **Mixed value + type** → one statement with the type specifiers marked inline: `import { value, type X } from '...'`.
+
+```ts
+import type { ApiResponse } from './requestHandler';    // type-only module — statement form
+import { fetchCase, type Case } from '../models/cases'; // mixed value + type — inline form
+```
+
+Reach for the inline `type` modifier only when the same import also pulls a value; otherwise prefer the statement form. (eslint does not enforce `consistent-type-specifier-style`, so both forms pass lint — apply this by hand.)
+
+> **React's own types are an exception**: reference them through the `React.` namespace (`React.FC`, `React.ReactNode`, `React.JSX.Element`) via `import type React from 'react'`, not named imports. See `ref-md-js-react`.
+
+### Filename casing for JS / TS files
+
+Use **camelCase** for JavaScript and TypeScript filenames when the file exports a named utility, helper, or script. Do not use dashed filenames like `path-utils.mjs` or `fetch-user.ts`; prefer `pathUtils.mjs` or `fetchUser.ts`.
+
+When the file name is already scoped by its folder, prefer the shortest clear name. For example, inside `src/utils/`, `path.mjs` is better than `pathUtils.mjs`.
+
+### JSDoc on throwing functions
+
+When you add JSDoc to a TypeScript function that can throw, include an explicit `@throws` entry. Do not leave exceptional behavior implicit when the function is already documented.
+
+This applies equally to `.ts`, `.mts`, `.js`, and `.mjs` files that use JSDoc-based typing or API documentation.
+
+### Prefer erasable types over `enum` / `namespace`
+
+For **new** code, prefer TypeScript constructs that are erased at compile time over ones that emit JavaScript: an `as const` object with `Values<T>` instead of `enum`, and ES module `import`/`export` instead of `namespace`. Emitting constructs (`enum`, `const enum`, `namespace`, a value-carrying `abstract class`) produce runtime output and resist tree-shaking (see [`references/types.md`](references/types.md)).
+
+This is a forward-looking preference, not a ban on existing code. The codebases still contain live `enum`s — sometimes deliberately, e.g. a numeric `enum` fed to `z.nativeEnum(...)` at an API boundary. Apply the `as const` preference to new declarations; leave working enums alone unless you are already refactoring them.
+
+### Prefer `.mts` for new runnable Node scripts
+
+Modern Node runs TypeScript directly by stripping types at load — `node script.mts` executes with no ts-node/tsx loader (flagged `--experimental-strip-types` on Node 22.6+, on by default on 23.6+). So a CLI or utility script can be authored in real TypeScript — inline `interface`/`type`, typed parameters — and still run directly, which is cleaner than the `@typedef`/`@param {…}` JSDoc scaffolding an `.mjs` file needs to carry the same types.
+
+For **new** runnable Node scripts, prefer `.mts` with real TypeScript over `.js`/`.mjs` + JSDoc. This is a forward preference, not a migration mandate: existing `.mjs`/JSDoc files stay as they are, and their JSDoc types remain the source of truth — matching the tone of the `enum`/`namespace` rule above.
+
+The two rules converge. Type-stripping requires exactly the erasable constructs the rule above already prefers: a `.mts` script that must run under type-stripping cannot use `enum`, `const enum`, `namespace`, or a value-carrying `abstract class` (parameter properties), because those emit runtime code the stripper won't produce. So "prefer erasable constructs" is not only about tree-shaking — it is what keeps an `.mts` file runnable.
+
+**Browser-eval'd source stays plain `.js`.** Source injected into a browser/page context and consumed as raw text — not imported as a module — must stay plain JavaScript with no type syntax and no module syntax, because nothing strips its types before it runs. (Concrete case: `mindoktor-testing`'s `src/common/interactions/*.js`, which `playwright-cli run-code` wraps and evaluates in the page.)
+
+**Wiring the first `.mts` into a repo:** add `**/*.mts` to the tsconfig `include` so the file is typechecked, and point any runner or path alias at the `.mts` path.
+
+## `const` Arrow Functions
+
+Declare functions as `const` arrow functions unless there is a specific reason to use a `function` declaration:
+
+```ts
+// Correct
+const formatDate = (date: string) => dayjs(date).format('YYYY-MM-DD');
+
+// Avoid
+function formatDate(date: string): string { ... }
+```
+
+**Legitimate exceptions** — keep `function` when:
+
+- **Body uses `arguments`** — arrow functions have no `arguments` object; common in legacy evaluator/variadic helpers.
+- **Self-referencing recursive IIFE** — arrow functions have no self-referencing name; `(function fn(n) { fn(c) })(root)` cannot be rewritten as an arrow.
+- **Generator** — `function*` syntax has no arrow equivalent.
+- **Hoisting required** — `function` declarations are hoisted; `const` is not.
+
+Leave these as `function` declarations and add a brief comment explaining why if non-obvious to the next reader.
+
+## Let TypeScript infer return types
+
+Do not annotate return types when the compiler can infer them. Add an explicit return type only when inference is insufficient or misleading:
+
+- **Type guard functions** — `(value: unknown): value is MyType`.
+- **Overloaded signatures** — required by the language.
+- **Public API contracts** where the inferred type would be too wide or unstable.
+- **Self-referencing recursive functions** — inference falls back to `any`; annotate explicitly (see [`references/low-hanging-fruit.md`](references/low-hanging-fruit.md)).
+
+```ts
+// Correct — let inference do the work
+const sum = (a: number, b: number) => a + b;
+
+// Correct — type guard requires explicit annotation
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+// Avoid — redundant annotation
+const sum = (a: number, b: number): number => a + b;
+```
+
+## Related Skills
+
+| Skill                        | When to load                                                        |
+| ---------------------------- | ------------------------------------------------------------------- |
+| `ref-md-dev-coding-patterns` | Cross-cutting naming, comments, code organization, nullish defaults |

--- a/.claude/skills/ref-md-js-typescript/references/low-hanging-fruit.md
+++ b/.claude/skills/ref-md-js-typescript/references/low-hanging-fruit.md
@@ -121,15 +121,14 @@ import { type Case } from '../models/cases';
 import type { Case } from '../models/cases';
 ```
 
-When the same module gives you both values and types, split them onto separate lines instead of mixing `type` inline. Splitting lets the type-only line be erased cleanly and avoids confusing bundlers:
+When the same module gives you both a value and a type, mark the type specifier inline — one import line, and the specifier is still erased at compile time. Don't split it into a separate `import type` statement: the value keeps the module imported at runtime either way, so both forms emit identical JavaScript.
 
 ```ts
-// Before — inline type keyword
-import { type Theme, Box } from '@mui/material';
+// Before — no `type` modifier, so `Theme` is emitted as a runtime binding
+import { Box, Theme } from '@mui/material';
 
-// After — separate statements
-import type { Theme } from '@mui/material';
-import Box from '@mui/material/Box';
+// After — inline `type` marks the type-only specifier
+import { Box, type Theme } from '@mui/material';
 ```
 
 ---
@@ -179,8 +178,8 @@ Remove `index.ts` files you encounter and update callers to import from the spec
 type Direction = 'UP' | 'DOWN'; // duplicates the const object
 
 // After (import path is app-specific — see "Deep Relative Imports" above)
-import { type Values } from '@mindoktor/utils/types/objects'; // patient-app
-// import { type Values } from '@common/utils/objects';       // clinic-app
+import type { Values } from '@mindoktor/utils/types/objects'; // patient-app
+// import type { Values } from '@common/utils/objects';       // clinic-app
 export type Direction = Values<typeof Direction>;
 ```
 

--- a/.claude/skills/ref-md-js-typescript/references/low-hanging-fruit.md
+++ b/.claude/skills/ref-md-js-typescript/references/low-hanging-fruit.md
@@ -1,0 +1,438 @@
+# Low-Hanging Fruit
+
+Read this file when touching existing TypeScript code and looking for opportunistic improvements.
+
+Apply these fixes to code you are **already reading or modifying**. Do not make separate passes over untouched files.
+
+---
+
+## Braceless `if` Statements
+
+```ts
+// Before
+if (condition) doSomething();
+
+// After
+if (condition) {
+  doSomething();
+}
+```
+
+---
+
+## Replace `any` with a Precise Type
+
+```ts
+// Before
+const handleResponse = (data: any) => { ... };
+
+// After
+const handleResponse = (data: ApiResponse<CasesResponse>) => { ... };
+```
+
+When the shape is genuinely unknown, prefer `unknown` over `any` — it forces you to narrow before using it.
+
+```ts
+// Better than any — forces narrowing
+const handleUnknown = (data: unknown) => {
+  if (typeof data === 'string') {
+    console.log(data.toUpperCase());
+  }
+};
+```
+
+---
+
+## Replace `function` Declarations with `const` Arrow Functions
+
+```ts
+// Before
+function formatName(first: string, last: string): string {
+  return `${first} ${last}`;
+}
+
+// After
+const formatName = (first: string, last: string): string => `${first} ${last}`;
+```
+
+Keep `function` only for the [legitimate exceptions](../SKILL.md#const-arrow-functions) — `arguments`, self-referencing recursive IIFEs, generators, and hoisting.
+
+---
+
+## Default Export → Named Export (Non-Component Values)
+
+Utilities, hooks, and other non-component values use **named** exports — never `export default function helper()`. Named exports keep import names consistent and greppable.
+
+```ts
+// Before
+export default function formatName(first: string, last: string) { ... }
+
+// After
+export const formatName = (first: string, last: string) => { ... };
+```
+
+React components are the exception — they use default exports; see `ref-md-js-react`.
+
+---
+
+## Non-Null Assertion (`!`) → Proper Guard
+
+```ts
+// Before
+console.log(user!.name);
+
+// After
+if (user == null) return;
+console.log(user.name);
+```
+
+---
+
+## `as` Assertion → Type Guard
+
+```ts
+// Before
+const id = (event.target as HTMLInputElement).value;
+
+// After — when the type can be verified
+if (!(event.target instanceof HTMLInputElement)) return;
+const id = event.target.value;
+```
+
+---
+
+## Missing `import type` on Type-Only Imports
+
+```ts
+// Before
+import { Case } from '../models/cases'; // only used in annotations
+
+// After
+import { type Case } from '../models/cases';
+```
+
+When every binding in an import is a type, hoist it to a dedicated `import type` statement so the line is erased entirely at compile time:
+
+```ts
+// Before — inline keyword, still emits a runtime import line
+import { type Case } from '../models/cases';
+
+// After — whole statement erased
+import type { Case } from '../models/cases';
+```
+
+When the same module gives you both values and types, split them onto separate lines instead of mixing `type` inline. Splitting lets the type-only line be erased cleanly and avoids confusing bundlers:
+
+```ts
+// Before — inline type keyword
+import { type Theme, Box } from '@mui/material';
+
+// After — separate statements
+import type { Theme } from '@mui/material';
+import Box from '@mui/material/Box';
+```
+
+---
+
+## Deep Relative Imports → Aliased Imports
+
+Replace deep relative imports (`../../..` or deeper) with the app's stable aliased path — stable when files move and easier to read. **Which alias depends on the app**, so check what the app actually provides before rewriting:
+
+- **patient-app (mindoktor-app)** — `@mindoktor/*` Yarn **workspace package names** (`@mindoktor/utils`, `@mindoktor/api`, …), resolved through the monorepo's workspaces and `transpilePackages`. Crossing a *package* boundary.
+- **clinic-app (mindoktor)** — has **no** `@mindoktor/*` packages; it uses tsconfig `paths` aliases for its own `src/` (`@common/*`, `@state/*`, `@api/*`, `@components/*`, …). Crossing a *directory* boundary within one app.
+
+```ts
+// Before — fragile, breaks when the file is moved
+import { useSomething } from '../../../../utils/useSomething';
+import type { Values } from '../../../../../utils/types/objects';
+
+// After (patient-app) — workspace package name
+import { useSomething } from '@mindoktor/utils/useSomething';
+import type { Values } from '@mindoktor/utils/types/objects';
+
+// After (clinic-app) — tsconfig path alias
+import type { Values } from '@common/utils/objects';
+```
+
+Relative imports are fine for same-directory or one level up (`./helpers`, `../types`). Reach for the aliased import as soon as the chain hits two or more `..`.
+
+---
+
+## Barrel `index.ts` Files → Direct Imports
+
+```ts
+// Before
+import { useCasesApi } from '../cases'; // imports from a barrel index
+
+// After
+import { useCasesApi } from '../cases/hooks/useCasesApi';
+```
+
+Remove `index.ts` files you encounter and update callers to import from the specific file. Never create new barrel files.
+
+---
+
+## `Values` Helper Instead of Manual Union Extraction
+
+```ts
+// Before
+type Direction = 'UP' | 'DOWN'; // duplicates the const object
+
+// After (import path is app-specific — see "Deep Relative Imports" above)
+import { type Values } from '@mindoktor/utils/types/objects'; // patient-app
+// import { type Values } from '@common/utils/objects';       // clinic-app
+export type Direction = Values<typeof Direction>;
+```
+
+---
+
+## Implicit Boolean Coercion (`strict-boolean-expressions`)
+
+`@typescript-eslint/strict-boolean-expressions` flags conditions that rely on JavaScript's truthiness rules. The fix depends on the type — pick the form that matches your intent.
+
+**Nullable boolean** — `undefined` sneaks through as falsy:
+
+```ts
+// Before
+if (isActive) { ... }
+
+// After — explicit
+if (isActive === true) { ... }
+// or, if false and undefined should behave the same:
+if (isActive != null && isActive) { ... }
+```
+
+**Nullable string** — `''` and `undefined` are both falsy, but they often mean different things:
+
+```ts
+// Before
+if (name) { ... }
+
+// After — choose based on intent
+if (name != null && name !== '') { ... } // exclude both nullish and empty
+if (name != null) { ... }                // exclude only nullish, allow ''
+```
+
+**Nullable number** — especially dangerous because `0` is falsy:
+
+```ts
+// Before — 0 is a valid value but treated as falsy
+if (caseId) { ... }
+
+// After — explicit nullish check preserves 0
+if (caseId != null) { ... }
+```
+
+**`any` in a conditional** — fix the type first, then apply the appropriate pattern above. If the type is genuinely unknown, narrow explicitly.
+
+**Object always truthy** — the condition is pointless; remove it or check what was actually intended (e.g., a property on the object).
+
+**Split null/undefined check** — collapse `x === undefined || x === null` to `x == null` (and the negation to `x != null`). `== null` matches both `null` and `undefined` and nothing else, so it is exact, not a weak-truthiness shortcut.
+
+These rules apply to inline JSX render guards too — `!!` is not an exception. Pick the form by type exactly as for an `if` condition:
+
+```tsx
+// Before — !! to coerce for conditional rendering
+{!!description && <Box>{description}</Box>}
+{!!warn && <WarningBar />}
+
+// After
+{description != null && description !== '' && <Box>{description}</Box>} // nullable string
+{warn === true && <WarningBar />}                                       // nullable boolean
+```
+
+---
+
+## Nested `if`/`else` → Early Returns
+
+Guard against bad cases first, then keep the happy path flat.
+
+```ts
+// Before — nested, happy path buried
+const formatLabel = (data: Data | null): string => {
+  if (data != null) {
+    if (data.items.length > 0) {
+      return data.items.join(', ');
+    } else {
+      return 'Empty';
+    }
+  } else {
+    return 'Loading';
+  }
+};
+
+// After — guard clauses first, happy path last
+const formatLabel = (data: Data | null): string => {
+  if (data == null) {
+    return 'Loading';
+  }
+  if (data.items.length === 0) {
+    return 'Empty';
+  }
+  return data.items.join(', ');
+};
+```
+
+---
+
+## Unused Imports and Variables
+
+Remove them. ESLint catches most, but occasionally dead imports survive — clean them up when you see them in a file you are already editing.
+
+---
+
+## Recursive Functions Need an Explicit Return Type
+
+A function that references itself in a return position (directly or via a mutually-recursive helper) cannot have its return type inferred — TypeScript reports `TS7023` / `TS7024` and falls back to `any`. Annotate the return type explicitly.
+
+```ts
+// Before — TS7023: implicit any return
+const getNode = (node: Node, index: string) => {
+  if (node.index === index) {
+    return node;
+  }
+  return node.children?.map((child) => getNode(child, index)).find(Boolean);
+};
+
+// After — annotate the return type
+const getNode = (node: Node, index: string): Node | undefined => { ... };
+```
+
+---
+
+## Inline Date Formatting → Shared Date Helper
+
+Don't hardcode date format strings or locale logic inline — use the project's locale-aware date helper so formatting and locale stay consistent:
+
+- clinic-app: `dateTimeFormats` constants from `@common/utils/format` (dayjs).
+- patient-app: `useDate()` → `formatDate` / `formatShortDate` from `packages/localization/src/hooks/useDate.ts` (date-fns).
+
+```ts
+// Before — inline format string, no shared locale handling
+dayjs(date).format('YYYY-MM-DD');
+```
+
+---
+
+## Stray `console.log` Statements
+
+Remove `console.log` calls left from debugging. If a log has permanent value, convert it to proper logging (Sentry or the project's logger) rather than leaving raw `console.*` calls behind.
+
+---
+
+## Plain Comments on Exports → JSDoc
+
+Comments that describe an exported function, variable, or constant should use JSDoc (`/** */`) so they appear in VS Code hover tooltips at call sites. Plain `//` comments are invisible outside the file.
+
+When the exported function can throw, include an explicit `@throws` entry in the JSDoc so callers can see that behavior at the call site.
+
+Keep plain `//` comments for **implementation details inside a function body** — those are only useful when reading the source, not when calling the function.
+
+```ts
+// Before — invisible at call sites
+// Formats and validates the SSN to YYYYMMDD-XXXX.
+export const formatSsn = (val: string) => { ... };
+
+// After — appears in hover tooltips
+/** Formats and validates an SSN to YYYYMMDD-XXXX. */
+export const formatSsn = (val: string) => { ... };
+
+/**
+ * Validates the payload before saving.
+ * @throws {ValidationError} When the payload is invalid.
+ */
+export const savePayload = (payload: Payload) => { ... };
+```
+
+Implementation details stay as plain comments:
+
+```ts
+export const formatDateOfBirth = (dateOfBirth: string) => {
+  // Treat date of birth as UTC so the date is the same in all timezones.
+  return dayjs.utc(dateOfBirth).format('L');
+};
+```
+
+**Strip redundant JSDoc types in TypeScript.** JSDoc should describe *purpose*, not restate types the compiler already provides. When JSDoc carries `@param {type}` / `@returns {type}` tags on TypeScript code, drop the `{type}` — and drop the whole tag when it adds nothing beyond the signature:
+
+```ts
+// Before — JSDoc restates types TypeScript already knows
+/**
+ * @param {number} id - The case id
+ * @returns {Promise<Case>} The case
+ */
+const getCase = async (id: number) => { ... };
+
+// After — keep only what the signature does not say
+/** Fetches full case details, including journal entries. */
+const getCase = async (id: number) => { ... };
+```
+
+This applies to TypeScript (`.ts` / `.tsx`) only. In legacy `.js` / `.mjs` files the JSDoc types **are** the source of truth — keep them (see the legacy `.js` section below).
+
+---
+
+## JSDoc `@import` for Legacy `.js` Files
+
+When a `.js` file is too large or too risky to convert to TypeScript, add JSDoc types in place. Use the `@import` form to bring types into scope — it is shorter and supported by the TypeScript checker that runs on `.js` files.
+
+When a documented function can throw, include `@throws` in the JSDoc alongside the parameter and return type information.
+
+**Bring types into scope with `@import`**, not `@typedef` indirection:
+
+```js
+// Before — verbose, every type needs its own redeclaration
+/** @typedef {import('../types').AppDispatch} AppDispatch */
+/** @typedef {import('../types').GetState} GetState */
+
+// After — single import line, types usable directly
+/** @import { AppDispatch, GetState } from '../types'; */
+```
+
+**Type function parameters inline:**
+
+```js
+/** @import { AppDispatch, GetState } from '../types'; */
+
+export const fetchSomething =
+  (caseId) =>
+  async (
+    /** @type {AppDispatch} */ dispatch,
+    /** @type {GetState} */ getState
+  ) => {
+    const state = getState();
+    // ...
+  };
+```
+
+```js
+/** @import { ValidationError } from '../errors'; */
+
+/**
+ * Parses the user-provided JSON settings.
+ * @param {string} rawSettings
+ * @throws {ValidationError} When the JSON is invalid.
+ */
+export const parseSettings = (rawSettings) => {
+  return JSON.parse(rawSettings);
+};
+```
+
+**Annotate non-trivial values** so type narrowing works:
+
+```js
+/** @import { AppState } from './types'; */
+
+/** @type {AppState} */
+const initialState = {
+  ready: false,
+  online: undefined,
+};
+```
+
+Rules:
+
+- Prefer `@import { … } from '…'` over `@typedef {import('…').Name} Name`.
+- Do not use inline `/** @type {import('…').Name} */` more than once for the same type — `@import` it at the top.
+- Convert pre-existing `@typedef`-with-`import` indirection to the `@import` form when you encounter it (Boy Scout fix).
+- If a documented function throws, add `@throws` to the JSDoc rather than leaving the failure mode implicit.

--- a/.claude/skills/ref-md-js-typescript/references/types.md
+++ b/.claude/skills/ref-md-js-typescript/references/types.md
@@ -1,0 +1,258 @@
+# Types, Interfaces, and Zod
+
+Read this file when writing TypeScript types, interfaces, lookup tables, type guards, or null checks.
+
+---
+
+## Interfaces Over Type Aliases for Object Shapes
+
+Use `interface` for object shapes — it gives cleaner error messages and is erased at compile time with no runtime cost.
+
+```ts
+// Correct
+interface UserProfile {
+  id: number;
+  name: string;
+  email?: string;
+}
+
+// Avoid for object shapes
+type UserProfile = {
+  id: number;
+  name: string;
+};
+```
+
+Use `type` for unions, intersections, and aliases of primitives. For a closed set of string or numeric values, prefer a `const` object with a derived type — it gives you a runtime-accessible lookup table and a type in one declaration:
+
+```ts
+// Preferred for closed sets
+export const Status = {
+  Active: 'active',
+  Inactive: 'inactive',
+  Pending: 'pending',
+} as const;
+export type Status = Values<typeof Status>; // 'active' | 'inactive' | 'pending'
+
+// Fine for open unions or primitive aliases
+type Id = number;
+type Direction = 'ltr' | 'rtl';
+```
+
+---
+
+## Lookup Tables
+
+For a closed set of named values, use a `const` object with `as const`.
+
+```ts
+// Preferred
+export const OrderStatus = {
+  Pending: 1,
+  InProgress: 2,
+  Finished: 3,
+} as const;
+
+// Derive the union type from the object
+export type OrderStatus = Values<typeof OrderStatus>;
+// → number (1 | 2 | 3)
+```
+
+The `Values` helper lives at a different import path per app — patient-app exposes it as the `@mindoktor/utils` workspace package, clinic-app as a tsconfig `@common/*` alias:
+
+```ts
+// patient-app (mindoktor-app)
+import { type Values } from '@mindoktor/utils/types/objects';
+// clinic-app (mindoktor)
+import { type Values } from '@common/utils/objects';
+```
+
+Compare against the constant, never the raw string/number literal — this covers `===` checks and `switch` cases:
+
+```ts
+// Before — raw literals
+if (status === 2) { ... }
+switch (status) {
+  case 1: ...
+  case 2: ...
+}
+
+// After — constants
+if (status === OrderStatus.InProgress) { ... }
+switch (status) {
+  case OrderStatus.Pending: ...
+  case OrderStatus.InProgress: ...
+}
+```
+
+A literal array used with `.includes()` narrows the argument type and can reject the wider union — rewrite as explicit `===` comparisons against the constants rather than casting:
+
+```ts
+// Before
+[1, 2].includes(status)
+
+// After
+status === OrderStatus.Pending || status === OrderStatus.InProgress
+```
+
+---
+
+## Infer Types from Zod When Possible
+
+In the API layer, types are inferred from Zod schemas. Do not hand-write types that duplicate a schema.
+
+```ts
+// Correct — single source of truth
+export const OrderSchema = z.object({
+  id: z.number(),
+  status: z.nativeEnum(OrderStatus),
+});
+export type Order = z.infer<typeof OrderSchema>;
+
+// Avoid — duplicates the schema
+export interface Order {
+  id: number;
+  status: OrderStatus;
+}
+```
+
+`z.nativeEnum` accepts either a real `enum` or an `as const` object — so the `as const` lookup-table style above pairs with it directly, no `enum` required:
+
+```ts
+const OrderStatus = { Pending: 1, InProgress: 2 } as const;
+z.nativeEnum(OrderStatus);
+```
+
+---
+
+## Type Guards Over Assertions
+
+Prefer runtime type guards over `as` assertions. Guards narrow the type for both the compiler and at runtime.
+
+```ts
+// Correct
+if (typeof value !== 'string') {
+  throw new Error('Expected string');
+}
+doSomethingWith(value); // narrowed to string
+
+// Avoid — silences the compiler but does not validate at runtime
+const value = someValue as string;
+```
+
+## Null Handling
+
+`strict: true` enables `strictNullChecks`. Never widen a type to bypass null checks.
+
+```ts
+// Correct
+if (user == null) return;
+console.log(user.name); // safe
+
+// Avoid
+console.log(user!.name); // non-null assertion hides real bugs
+```
+
+---
+
+## Representing Absent Values
+
+Model absence explicitly — use `null` / `undefined`, never an empty string, `0`, or a sentinel standing in for "missing". Empty defaults hide missing data from the type system. (This is the TypeScript side of a cross-language principle — see `ref-md-dev-coding-patterns` for the rationale and the Go side.)
+
+- **Parse external/route params with a validating helper** that returns `null` on invalid input — never `Number()`, which silently yields `NaN` or `0`. Use the project's `parseId` / `parseUUID`: `@common/utils/validation` in clinic-app, `packages/utils/strings/strings.ts` in patient-app.
+- **For a broad emptiness check**, use the project's empty-value helper rather than ad-hoc truthiness — `isNonEmpty` / `isEmpty` (`@common/utils/emptyValues`) in clinic-app, or `isEmptyObject` (`packages/utils/objects/isEmptyObject.ts`, which treats an object as empty when every value is `null` or `''`) in patient-app. Each helper defines "empty" differently, so check its logic before relying on it.
+- **At API boundaries, model absence in the schema** — `z.string().nullable()` or `.optional()` — instead of making a field always-present with a fallback empty value.
+- For truthiness pitfalls (`0` / `''` are falsy) see [`low-hanging-fruit.md`](low-hanging-fruit.md) (§ strict-boolean-expressions); for exhaustive switches use `assertUnreachable` (below).
+
+---
+
+## Arrays and Objects Are Not Safe to Index
+
+Treat direct indexing (`arr[i]`, `obj[key]`) as unsafe unless you have already proven the key/index exists.
+
+Even when the code "usually works," unchecked indexing is a common source of `undefined` bugs.
+
+```ts
+// Risky: can be undefined at runtime
+const first = users[0];
+const statusLabel = statusLabels[status];
+```
+
+Preferred strategies:
+
+1. Guard array access with length checks or bounds checks before indexing.
+2. Prefer `Array.prototype.at()` when reading positional elements; it returns `T | undefined`, which forces handling.
+3. Prefer `find`, `some`, `every`, `filter`, and `map` over manual index math when searching or transforming.
+4. For object dictionaries, check with `Object.hasOwn(...)` before reading a dynamic key.
+5. For key-value lookups with dynamic keys, prefer `Map` + `has`/`get` when feasible.
+6. Use `for...of` or `Object.entries()` iteration instead of indexing when traversing collections.
+
+```ts
+const maybeUser = users.at(0);
+if (maybeUser == null) return;
+
+if (!Object.hasOwn(statusLabels, status)) {
+  return 'Unknown';
+}
+const statusLabel = statusLabels[status];
+
+const openCase = cases.find((currentCase) => currentCase.status === 'open');
+if (openCase == null) return;
+```
+
+If your repository enables stricter indexed access checks, keep them enabled and fix call sites with explicit guards instead of widening types or adding assertions.
+
+**Do not index with a fabricated fallback key.** `obj[id ?? '']` (or `obj[id || '']`) reads as "handled" but silently looks up a key that does not exist (`''`) when `id` is nullish — masking the real question of whether the entry is present. Guard the key explicitly instead:
+
+```ts
+// Before — meaningless '' lookup when id is missing
+const label = labels[id ?? ''];
+
+// After — guard the key, then look it up
+if (id == null || !Object.hasOwn(labels, id)) {
+  return 'Unknown';
+}
+const label = labels[id];
+```
+
+Writing to a fabricated key is occasionally intentional (a catch-all bucket) — if so, leave a comment saying why.
+
+**Partial lookup map: prefer `Partial<Record<…>>` over an `as keyof typeof` cast.** When a map only has entries for *some* members of a key union, indexing it with the full union is a real `TS7053`. The usual `as keyof typeof obj` band-aid lies — it asserts the key always exists and silences the very `== null` check that handles the missing ones. Annotate the map as partial so indexing honestly yields `V | undefined`, and capture the result before the null check (re-indexing twice does not carry the narrowing):
+
+```ts
+// Before — cast asserts the key always exists
+const transforms = { binary: ..., choice: ... }; // ~14 of ~25 node types
+const fn = transforms[type as keyof typeof transforms];
+
+// After
+const transforms: Partial<Record<NodeType, (value: unknown) => unknown>> = {
+  binary: ...,
+  choice: ...,
+};
+const transform = transforms[type]; // (…) | undefined — honestly typed
+if (transform == null) {
+  return value;                      // member with no entry
+}
+return transform(value);
+```
+
+Note the `in` operator narrows the **object**, not the key: `if (key in obj)` does not narrow a wide `key` down to `keyof typeof obj`, so the `Partial<Record<…>>` annotation (not an `in` check) is what makes the index legal.
+
+---
+
+## Exhaustive Checks with `assertUnreachable`
+
+Use `assertUnreachable` in `switch` statements to guarantee all cases are handled — the compiler errors if a new case is added without being covered. The import path is app-specific: `@mindoktor/utils/types/assertUnreachable` in patient-app, `@common/utils/assertUnreachable` in clinic-app.
+
+```ts
+// patient-app (mindoktor-app)
+import { assertUnreachable } from '@mindoktor/utils/types/assertUnreachable';
+// clinic-app (mindoktor)
+import { assertUnreachable } from '@common/utils/assertUnreachable';
+
+switch (status) {
+  case OrderStatus.Pending: return handlePending();
+  case OrderStatus.Finished: return handleFinished();
+  default: assertUnreachable(status); // compile error if status has unhandled values
+}
+```

--- a/.claude/skills/ref-md-js-typescript/references/types.md
+++ b/.claude/skills/ref-md-js-typescript/references/types.md
@@ -62,9 +62,9 @@ The `Values` helper lives at a different import path per app — patient-app exp
 
 ```ts
 // patient-app (mindoktor-app)
-import { type Values } from '@mindoktor/utils/types/objects';
+import type { Values } from '@mindoktor/utils/types/objects';
 // clinic-app (mindoktor)
-import { type Values } from '@common/utils/objects';
+import type { Values } from '@common/utils/objects';
 ```
 
 Compare against the constant, never the raw string/number literal — this covers `===` checks and `switch` cases:

--- a/.claude/skills/tool-md-maintain-skills/SKILL.md
+++ b/.claude/skills/tool-md-maintain-skills/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: tool-md-maintain-skills
+description: >-
+  Audit, update, and reorganize agent skills against current ref-md-agents-skills-authoring
+  standards. Use when: a skill may be stale or outdated, the repo instruction
+  index (AGENTS.md, or a legacy copilot-instructions.md)
+  is bloated, multiple skills repeat the same rule, guidance is in the wrong file,
+  a copied skill references the wrong stack, a skill needs structural review
+  (folder layout, naming prefix, frontmatter, file placement), a long skill
+  should be split into references, a PR introduces changes that affect documented
+  conventions, or the user asks to synchronize skills with recent code changes.
+  Covers compliance audit, staleness detection, deduplication, ownership decisions,
+  structural fixes, reorganization, and diff-driven skill updates.
+metadata:
+  author: mindoktor
+  version: "3.14"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "agents"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+  shareable-skills.requires: "ref-md-agents-skills-authoring"
+  shareable-skills.suggests: "ref-md-agents-shareable-skills, ref-md-agents-local-tasks"
+---
+
+# Maintain Skills
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+Keep skills correct, current, and compliant with ref-md-agents-skills-authoring by auditing structure and content, fixing issues, and consolidating duplicated guidance.
+
+## Routing Table
+
+| Task                             | Read                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------ |
+| Diff-driven skill updates        | [`references/diff-driven-updates.md`](references/diff-driven-updates.md) |
+| Post-maintenance quality check   | [`references/checklist.md`](references/checklist.md)                     |
+| Automated validation commands    | [`references/automation.md`](references/automation.md)                   |
+| Skill structure and format rules | `ref-md-agents-skills-authoring`                                         |
+
+## When to Use
+
+- Auditing a skill against current ref-md-agents-skills-authoring standards.
+- Checking folder layout, naming prefix, frontmatter, or file placement.
+- Detecting and fixing stale content (wrong commands, outdated patterns, inherited references).
+- Reducing duplication across `.claude/skills/`.
+- Trimming the repo instruction index (`AGENTS.md`, or a legacy `.github/copilot-instructions.md`) without losing important rules.
+- Moving guidance into the right owning skill.
+- Adapting copied skill content to the actual stack of this repo.
+- Splitting a large skill into smaller reference files.
+- Reviewing whether a rule should be always-on or loaded on demand.
+- Updating skills after the codebase, conventions, or tooling have changed.
+- A PR or working tree diff introduced changes that affect documented conventions.
+- Synchronizing skills with recent code changes after a feature is merged.
+
+## Vendored Skills — Never Fix Drift In Place
+
+Some skills are **vendored**: copied from an upstream repo that owns them (look for a `vendored-sha` pin in the skill's frontmatter — see `ref-md-agents-shareable-skills`). Editing a vendored copy directly causes drift — the change is lost on the next re-vendor and never reaches the other consumers.
+
+When maintenance finds drift, staleness, or any needed fix in a vendored skill, **do not edit the vendored copy to correct it.** The fix must happen upstream and be re-vendored back, so every consumer stays in sync. File it as a local task instead:
+
+- **If the upstream repo is cloned locally** (for skills owned by `mindoktor/agentic-tools`, check `~/dev/agentic-tools`) — create a new local task **in the upstream repo** according to `ref-md-agents-local-tasks`, so the agentic-tools agent picks it up.
+- **Otherwise** — create a new local task in the **repo currently in use** according to `ref-md-agents-local-tasks`, then tell the user the normal procedure: the fix must be made in `agentic-tools` upstream and re-vendored. They can clone `agentic-tools` themselves to action it, or hand it off to another dev (likely Fabio) who maintains that repo.
+
+Write the task for a fresh agent: which skill, what is wrong, why it matters, and any local workaround applied. This is a **problem hand-off** — the upstream agent owns the skill and has context you may lack. Any fix you include is a **hint, not a prescription**: frame it as one possible way to be validated on the way in, and leave the solution open for the handling agent to analyze and decide. See `ref-md-agents-local-tasks` (Rules for the AI) — a filed solution is a hint, never a prescription.
+
+The only exception is a **deliberate, repo-specific delta** the user explicitly wants to keep local (it then diverges from upstream — set `forked-from` per `ref-md-agents-shareable-skills`). Do not take this route to "just fix" drift — ask the user first, and default to the upstream-task route.
+
+## Procedure
+
+| Step | What                                           | Why                                                           | When                                                      |
+| ---- | ---------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------- |
+| 1    | Load `ref-md-agents-skills-authoring`          | It is the source of truth for structure, naming, and patterns | Start of every maintenance pass                           |
+| 2    | Audit each skill against the standard          | Catches structural drift before addressing content            | After ref-md-agents-skills-authoring is confirmed current |
+| 3    | Inventory content and detect staleness         | Cannot fix without knowing what exists and what is wrong      | After audit — before moving anything                      |
+| 4    | Choose the right home for each rule            | One source of truth prevents contradictions                   | After inventory is complete                               |
+| 5    | Fix, consolidate, and restructure              | Apply audit findings and deduplication in one pass            | When the target state for each skill is decided           |
+| 6    | Update descriptions, routing, and registration | Moved or renamed guidance must remain discoverable            | After edits are done                                      |
+| 7    | Verify the result                              | Catches broken links, lost guidance, and remaining issues     | After all edits are committed                             |
+
+### Step 1 — Load `ref-md-agents-skills-authoring`
+
+- Read `ref-md-agents-skills-authoring` first.
+- If the maintenance task suggests the authoring rules themselves may be stale, revisit the external resources referenced there.
+- If refreshing `ref-md-agents-skills-authoring` would expand scope, ask the user before proceeding.
+
+### Step 2 — Audit Against the Standard
+
+For each skill in scope, check every item below. Flag violations but do not fix yet — collect the full picture first.
+
+#### Naming
+
+- Every skill uses either `tool-` or `ref-` — no unprefixed skills.
+- `tool-` skills guide multi-step workflows; name uses a concrete action verb (`tool-md-create-db-migration`, not `tool-helper`).
+- `ref-` skills provide read-only knowledge (conventions, rules, lookup tables); name uses a knowledge domain (`ref-md-db-migrations`, not `ref-utils`).
+- No `ref-` skill orchestrates a workflow (extract to `tool-` if it does).
+- Folder name is kebab-case, 1–64 chars, no leading/trailing/consecutive hyphens.
+
+#### Frontmatter
+
+- `name` field matches the folder name exactly.
+- `description` starts with an action verb, includes "Use when:" triggers, ends with "Covers …" topics.
+- `description` is 1–1024 chars and contains keywords for discoverability.
+- `metadata.author` and `metadata.version` are present.
+- Optional fields (`license`, `compatibility`, `allowed-tools`) are used appropriately.
+
+#### Folder Structure
+
+- `SKILL.md` exists and serves as the dispatcher (metadata + routing), not a monolith.
+- Documentation lives in `references/`, not inlined in SKILL.md.
+- Templates, scaffolds, and output format examples live in `assets/`, not `references/`.
+- Executable code lives in `scripts/`.
+- Test cases live in `evals/`.
+- Custom subdirectories beyond the four named ones are **allowed** (the spec permits "any additional files or directories") — do not flag a directory as spec-divergent purely because its name is not `references/`/`assets/`/`scripts/`/`evals/`. Flag it only when its content fits one of the four standard roles and should move there.
+- No files are placed directly in the skill root beside SKILL.md (use subdirectories).
+
+#### Content Structure
+
+- SKILL.md is under 500 lines.
+- Routing table maps tasks to subfiles.
+- Subfile links use relative paths only.
+- File references are one level deep (no reference loading another reference loading another).
+- Sections follow the recommended anatomy where applicable: title, purpose, prerequisites, routing table, when-to-use, scope, rules, related skills. Simple skills need not include every section.
+
+#### Markdown Quality
+
+- No markdownlint violations: MD032 (blank lines around lists), MD024 (duplicate headings), MD033 (inline HTML).
+- Tables use aligned style — pipe characters line up across all rows (project convention).
+- Comments explain business reasons, not logic restated in English.
+
+### Step 3 — Inventory and Detect Staleness
+
+Check every rule and example against the repo's actual state:
+
+| Signal                                          | Action                                                     |
+| ----------------------------------------------- | ---------------------------------------------------------- |
+| Command references a tool not in `package.json` | Rewrite to use the repo's actual command                   |
+| Example uses a library not in dependencies      | Replace with the library this repo actually uses           |
+| File path in a rule does not exist              | Update to the correct path or remove the reference         |
+| Rule contradicts current conventions            | Rewrite to match current practice, or delete if obsolete   |
+| Skill was copied from another project           | Audit every command, path, and framework reference for fit |
+
+Also check for duplicated guidance across skills and between skills and the repo instruction index (`AGENTS.md`, or a legacy `.github/copilot-instructions.md`).
+
+Do not preserve inherited content that does not apply. Stale guidance is worse than no guidance.
+
+#### Diff-Driven Gap Analysis
+
+When on a feature branch or when the working tree has uncommitted changes, **always** run a diff-driven analysis as part of this step — do not rely solely on static audit. Follow the procedure in [`references/diff-driven-updates.md`](references/diff-driven-updates.md):
+
+1. Gather the diff against the repo's default branch (`git diff <default-branch> --name-only` — resolve it with `git symbolic-ref refs/remotes/origin/HEAD`; often `develop` or `main`).
+2. Classify changed files by domain skill using the mapping table in that reference.
+3. Load each affected skill and compare its documented patterns against what the diff introduced.
+4. Identify skill gaps — three categories:
+   - **Conventions/gotchas**: new patterns, constraints, or pitfalls discovered during implementation.
+   - **Feature documentation**: new capabilities or changed behavior that the skill should describe as stable, present-tense reference material (not changelog entries).
+   - **Structural changes**: new directories, renamed files, updated commands.
+5. Present a concrete update plan to the user before making changes.
+
+This ensures maintenance always captures lessons learned from recent work — not just structural compliance but also an up-to-date description of how each domain area works.
+
+### Step 4 — Choose the Right Home
+
+| If the rule…                                                  | Then it belongs in…                                                                     |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Applies to most work in the repo (workflow, safety, approval) | The repo instruction index (`AGENTS.md`, or a legacy `.github/copilot-instructions.md`) |
+| Is specific to a domain (styling, testing, deployment)        | The owning domain skill                                                                 |
+| Is a long example, checklist, or template                     | A skill's `references/` or `assets/` subfile                                            |
+| Applies across all repos (personal workflow, security)        | Home-level instructions or home-level skill                                             |
+
+### Step 5 — Fix, Consolidate, and Restructure
+
+- **Audit fixes**: rename prefixes, move misplaced files to the right subdirectory, update frontmatter fields, split oversized SKILL.md files.
+- **Deduplication**: remove duplicate wording — do not keep multiple nearly-identical copies.
+- **Routing summaries**: leave short routing entries in the instruction index (`AGENTS.md`, or a legacy `.github/copilot-instructions.md`) when the detailed rule now lives in a skill.
+- **Stack alignment**: replace stale stack references with the repo's actual tools and conventions.
+- **Scope conflicts**: if a rule exists in both home instructions and a project skill, the project skill wins for project-specific behavior; home instructions win for personal workflow.
+
+### Step 6 — Update Descriptions, Routing, and Registration
+
+- Update `description` fields so moved or renamed guidance stays discoverable via keywords.
+- Update routing tables in the instruction index (`AGENTS.md`, or a legacy `.github/copilot-instructions.md`) and affected skills.
+- Add or update "Related skills" sections if dependencies changed.
+- Register new or renamed skills in the appropriate instructions file; unregister removed skills.
+
+### Step 7 — Verify
+
+Run the [maintenance checklist](./references/checklist.md).
+
+Then run the automated checks in [`references/automation.md`](references/automation.md) so the pass is repeatable and not dependent on manual inspection.
+
+If this maintenance pass was performed as part of a PR, mark the skill-maintenance checklist item in the PR template as done:
+
+```text
+- [x] I ran `/tool-md-maintain-skills` and updated skills
+```
+
+## Decision Rules
+
+| What                                                                                           | Why                                                            | When                                                                                                             |
+| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Keep always-on rules in the instruction index (`AGENTS.md` / legacy `copilot-instructions.md`) | They must load without skill activation                        | Workflow, safety, approval gates                                                                                 |
+| Move domain detail into the owning skill                                                       | Reduces top-level bloat, improves discoverability              | Styling, framework, testing, deployment rules                                                                    |
+| Split long skills into reference files                                                         | Keeps `SKILL.md` under 500 lines for fast activation           | When a skill exceeds ~400 lines                                                                                  |
+| Rewrite stale content, do not preserve it                                                      | Wrong guidance is worse than missing guidance                  | Copied skills, outdated conventions                                                                              |
+| Fix prefix violations before content issues                                                    | Structure errors affect every future interaction               | During audit                                                                                                     |
+| Ask before duplicating a rule                                                                  | Duplication creates future drift                               | When ownership is unclear                                                                                        |
+| Never fix drift in a vendored skill in place                                                   | Editing the copy drifts from upstream and is lost on re-vendor | The skill has a `vendored-sha` pin — file a local task (upstream clone if present, else the repo in use) instead |
+
+## Related Skills
+
+| Skill                            | When to load                                                              |
+| -------------------------------- | ------------------------------------------------------------------------- |
+| `ref-md-agents-skills-authoring` | Structure, format, and naming rules for skills                            |
+| `ref-md-agents-shareable-skills` | Vendoring model, `vendored-sha` pins, visibility before editing a copy    |
+| `ref-md-agents-local-tasks`      | `.agents/tasks/new/` structure when filing an upstream-fix task for drift |

--- a/.claude/skills/tool-md-maintain-skills/references/automation.md
+++ b/.claude/skills/tool-md-maintain-skills/references/automation.md
@@ -1,0 +1,70 @@
+# Automated Skill Validation
+
+Use this after any skill update to run objective checks before finalizing.
+
+## Why
+
+Manual review is still needed for judgment calls, but structural quality checks should be automated to avoid regressions and reduce reviewer load.
+
+## Command Sequence
+
+Run these from the repo root.
+
+```bash
+git status --short
+```
+
+```bash
+node .claude/skills/ref-md-agents-skills-authoring/scripts/validateSkills.mts
+```
+
+Node runs these `.mts` scripts directly via native type-stripping, so no `ts-node` bootstrap is required — but it needs **Node 24** (type-stripping on by default) or **Node ≥ 22.6** with `--experimental-strip-types`. Pin the same version in CI; older Node will fail on the scripts' type annotations.
+
+```bash
+node .claude/skills/ref-md-agents-shareable-skills/scripts/validateSharing.mts
+```
+
+Validates portability metadata — `owner-prefix`/`owner`/`domain`/`visibility` — and the dependency graph.
+
+```bash
+# When the repo holds vendored copies of upstream skills
+node .claude/skills/ref-md-agents-shareable-skills/scripts/checkVendoredDrift.mts
+```
+
+Checks vendored copies against their `vendored-sha` pins and flags drift from upstream.
+
+```bash
+# Optional: if available in your environment
+skills-ref validate .claude/skills/ref-md-agents-skills-authoring
+```
+
+## What the local validators check
+
+`validateSkills.mts`:
+
+- Skill folder naming prefix (`tool-` / `ref-`) and kebab-case constraints.
+- Presence of `SKILL.md` in every skill folder.
+- Frontmatter essentials (`name`, `description`, `metadata.author`, `metadata.version`).
+- `name` equals folder name.
+- `description` contains both `Use when:` and `Covers`.
+- `SKILL.md` line-count budget (<= 500 lines).
+- Local markdown links resolve to existing files.
+- Markdown table alignment — any `.md` file whose tables `alignTables.mts` would reformat fails; fix it with `node .claude/skills/ref-md-agents-skills-authoring/scripts/alignTables.mts <file> --write` (or check one file with `--check`).
+
+`validateSharing.mts`:
+
+- `shareable-skills.owner-prefix`, `owner`, `domain`, and `visibility` are present and consistent with the skill name.
+- The dependency graph: `requires` targets exist and are not narrower in visibility than the depending skill.
+
+`checkVendoredDrift.mts` (only relevant when the repo holds vendored copies):
+
+- Each vendored skill's content matches its `vendored-sha` pin — flags copies that drifted from upstream or carry a stale pin.
+
+## Interpreting output
+
+- Exit code `0`: all checks passed.
+- Exit code `1`: one or more checks failed; fix listed issues and re-run.
+
+## Scope limits
+
+The validator does not replace semantic review. It cannot decide if guidance is correct for the codebase; it only verifies structure and integrity.

--- a/.claude/skills/tool-md-maintain-skills/references/checklist.md
+++ b/.claude/skills/tool-md-maintain-skills/references/checklist.md
@@ -1,0 +1,81 @@
+# Maintenance Checklist
+
+Use this checklist after auditing, reorganizing, updating, or consolidating skills and instructions.
+
+## Naming Compliance
+
+- [ ] Folder name uses the correct prefix: `tool-` for action skills, `ref-` for reference skills.
+- [ ] Folder name is kebab-case, 1–64 chars, no leading/trailing/consecutive hyphens.
+- [ ] `tool-` names use a concrete action verb after the prefix (not `tool-helper` or `tool-utils`).
+- [ ] `ref-` names use a knowledge domain after the prefix (not `ref-misc`).
+
+## Frontmatter
+
+- [ ] `name` field matches the folder name exactly.
+- [ ] `description` starts with an action verb, includes "Use when:" triggers, ends with "Covers …" topics.
+- [ ] `description` is 1–1024 chars and contains keywords that help agents match tasks.
+- [ ] `metadata.author` and `metadata.version` are present.
+- [ ] Optional fields (`license`, `compatibility`, `allowed-tools`) are used only when appropriate.
+
+## Folder Structure
+
+- [ ] `SKILL.md` exists and acts as a dispatcher, not a monolith.
+- [ ] Documentation lives in `references/`, not inlined in SKILL.md.
+- [ ] Templates, scaffolds, and output format examples live in `assets/`, not `references/`.
+- [ ] Executable code lives in `scripts/`.
+- [ ] Test cases live in `evals/`.
+- [ ] No stray files in the skill root beside SKILL.md.
+
+## Content Structure
+
+- [ ] SKILL.md is under 500 lines.
+- [ ] Routing table maps tasks to subfiles.
+- [ ] All subfile links use relative paths (`./references/...`, `./assets/...`).
+- [ ] File references are one level deep — no deeply nested reference chains.
+- [ ] Sections follow recommended anatomy where applicable: title, purpose, routing table, when-to-use, scope, rules, related skills. Simple skills need not include every section.
+
+## Deduplication
+
+- [ ] Each rule has one clear source of truth — no near-copies across files.
+- [ ] Duplicated wording was removed, not just annotated.
+- [ ] If a rule exists in both home and project scope, ownership is intentional and documented.
+
+## Placement
+
+- [ ] The repo instruction index (`AGENTS.md`, or a legacy `.github/copilot-instructions.md`) contains only repo-wide rules, workflow, routing, and safety guidance — not domain detail.
+- [ ] Domain-specific guidance lives in the owning skill.
+- [ ] Large examples, checklists, and templates live in `references/`, `assets/`, or `scripts/`.
+
+## Freshness
+
+- [ ] Commands in rules match the repo's actual `package.json` scripts.
+- [ ] Library and framework references match the repo's real dependencies.
+- [ ] File paths in rules point to files that actually exist.
+- [ ] Copied guidance has been fully adapted — no inherited commands, library names, or conventions from the source project remain.
+- [ ] Rules reflect current conventions, not historical ones.
+
+## Discoverability
+
+- [ ] Skill `description` fields contain keywords for the moved or updated guidance.
+- [ ] Routing tables in the instruction index (`AGENTS.md`, or a legacy `.github/copilot-instructions.md`) and affected skills are up to date.
+- [ ] "Related skills" sections reflect current dependencies.
+
+## Automation Checks
+
+- [ ] Run `node .claude/skills/ref-md-agents-skills-authoring/scripts/validateSkills.mts` and ensure it exits `0`.
+- [ ] If available, run `skills-ref validate` against changed skills.
+- [ ] Re-run automated checks after each fix pass until clean.
+- [ ] Keep manual checklist as final semantic review (automation is necessary, not sufficient).
+
+## Markdown Quality
+
+- [ ] No MD032 violations (blank lines around lists).
+- [ ] No MD024 violations (duplicate headings).
+- [ ] No MD033 violations (inline HTML — use backtick-wrapping for generic type syntax).
+- [ ] Tables use aligned style — pipe characters line up across all rows (project convention).
+
+## Registration
+
+- [ ] New or renamed skills are registered in the appropriate instructions file.
+- [ ] Removed skills are unregistered.
+- [ ] Cross-references in other skills updated after any rename.

--- a/.claude/skills/tool-md-maintain-skills/references/diff-driven-updates.md
+++ b/.claude/skills/tool-md-maintain-skills/references/diff-driven-updates.md
@@ -1,0 +1,111 @@
+# Diff-Driven Skill Updates
+
+When a PR or working tree diff introduces changes that may affect documented conventions, use this procedure instead of the full audit. It starts from the diff rather than from the skills themselves.
+
+## Workflow
+
+| Step | What                                                      | Why                                                           | When                              |
+| ---- | --------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------- |
+| 1    | Gather the diff against `develop` (or the specified base) | The diff is the source of truth for what changed              | Always — first step               |
+| 2    | Classify changed files by domain                          | Skills are organized by domain; classification drives routing | After the diff is gathered        |
+| 3    | Load affected skills                                      | Must read current content before proposing changes            | After classification              |
+| 4    | Identify skill gaps                                       | New patterns, commands, or conventions may not be covered yet | While reading affected skills     |
+| 5    | Draft the update plan                                     | The user must review before any edits happen                  | After gaps are identified         |
+| 6    | Present the plan to the user                              | Ensures alignment and avoids unwanted changes                 | Always — unless user pre-approved |
+| 7    | Execute the approved plan                                 | Apply skill updates and create new skills as needed           | After user confirms               |
+| 8    | Suggest doc updates if skill changes are insufficient     | Some changes belong in `docs/` rather than skills             | After skill updates are complete  |
+
+## Step 1 — Gather the Diff
+
+Diff against the repo's default branch (often `develop`, or `main` in some repos — substitute `<default-branch>` accordingly):
+
+```bash
+git diff <default-branch> --stat
+git diff <default-branch> --name-only
+```
+
+For a PR number:
+
+```bash
+gh pr diff <number> --name-only
+gh pr diff <number>
+```
+
+## Step 2 — Classify Changed Files
+
+Map each changed file to its domain skill. Adapt this mapping table to the project's actual skill inventory:
+
+| Path pattern                                   | Likely skill                                                       |
+| ---------------------------------------------- | ------------------------------------------------------------------ |
+| `.claude/skills/`                              | `ref-md-agents-skills-authoring`                                   |
+| `docs/architecture/`                           | architecture skill                                                 |
+| `Makefile`, `package.json`                     | Instruction index (`AGENTS.md` / legacy `copilot-instructions.md`) |
+| `AGENTS.md`, `.github/copilot-instructions.md` | meta — affects all skills                                          |
+
+## Step 3 — Load Affected Skills
+
+Read each affected skill's `SKILL.md` and relevant reference files. Pay attention to:
+
+- Commands and scripts referenced in the skill.
+- File paths and directory structures described.
+- Patterns, conventions, or rules that the diff may have changed.
+- Routing tables that may need new entries.
+
+## Step 4 — Identify Skill Gaps
+
+| Change type                     | Skill action needed                                                                             |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- |
+| New convention or pattern       | Add to the relevant skill (or create a new reference)                                           |
+| New or changed feature          | Document how the domain area works now (see below)                                              |
+| Changed command or script       | Update the command in the affected skill                                                        |
+| New directory or file structure | Update project structure section in the affected skill                                          |
+| Removed or renamed feature      | Remove or update references in the affected skill                                               |
+| New integration or service      | May need a new skill or a new reference file                                                    |
+| Build or tooling change         | Update the instruction index (`AGENTS.md` / legacy `copilot-instructions.md`) standard commands |
+
+### Documenting Features
+
+When a diff introduces a new capability or significantly changes how a domain area works, the relevant skill must reflect the new reality. This is not about logging what changed — it is about ensuring the skill describes **how things work now**.
+
+**Writing style**: describe the feature as stable, present-tense documentation. Do not write "we have added X" or "as of PR #1234" — write "the chat supports X" or "system messages render via Y." Skills are living reference material, not changelogs.
+
+**What to capture** (the things an agent cannot easily infer from reading code, or that would take too long to piece together):
+
+- Purpose and scope: what the feature does, why it exists, when it's used.
+- Architecture: key components, how they relate, where they live (entry points, not exhaustive file lists).
+- Non-obvious behaviors: hidden logic, intentional omissions, constraints that are easy to miss.
+- Extension points: how to add a new variant, with a concise step list.
+
+**What NOT to capture** (things obvious from reading the code itself):
+
+- Props of every component — the agent can read the file.
+- Full enumeration of every type/variant — unless the grouping logic is non-obvious.
+- Implementation details of individual functions.
+- Type definitions that are self-documenting.
+
+**Level of detail**: write for a fellow agent that needs to extend or modify the feature. It should know: (1) that the feature exists and what it does, (2) where to start looking, (3) what surprising constraints exist, and (4) how to add/change things. A short reference file (40–80 lines) is usually the right size. If you're listing every component's props, you've gone too deep. If you're only saying "messages exist," you're too shallow.
+
+**Where to put it**: add or update a domain-specific reference file in the owning skill. If the feature spans multiple domains, document each domain's portion in its own skill.
+
+## Steps 5–6 — Draft and Present the Plan
+
+Always present the plan to the user and wait for confirmation unless the user has pre-approved (e.g., "go ahead and update skills").
+
+Structure as:
+
+- **Updates to existing skills** — what changes, where, why.
+- **New skills or references** — only when an existing skill cannot absorb the change.
+- **Documentation suggestions** — things that belong in `docs/` rather than skills.
+
+## Steps 7–8 — Execute and Suggest Doc Updates
+
+After approval, apply changes following `ref-md-agents-skills-authoring` conventions. Commit skill updates separately from code changes when possible.
+
+If the diff introduced changes better documented in `docs/` than in skills (architecture decisions, API contracts, setup guides), list them as suggestions — do not act on them autonomously.
+
+## Gotchas
+
+- Do not update skills based on draft or work-in-progress code.
+- Prefer adding a reference file to an existing skill over creating a new skill.
+- If a change affects both a project skill and the instruction index (`AGENTS.md`, or a legacy `.github/copilot-instructions.md`), update the skill first, then update routing.
+- Verify the diff is against the correct base branch.

--- a/.claude/skills/tool-md-read-skills/SKILL.md
+++ b/.claude/skills/tool-md-read-skills/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: tool-md-read-skills
+description: >-
+  Load relevant project and global skills based on the current conversation context.
+  Use when: the user asks to load skills, at the start of a task, or whenever the
+  work shifts into a new area, to ensure the right domain knowledge is available. Scans the conversation for keywords and
+  matches them against the project's skill table in its instruction index
+  (AGENTS.md, or a legacy .github/copilot-instructions.md).
+  Covers keyword scanning, the skill-table lookup, and loading project and
+  global skills by context.
+metadata:
+  author: mindoktor
+  version: "1.3"
+  shareable-skills.owner-prefix: "md"
+  shareable-skills.owner: "mindoktor/agentic-tools"
+  shareable-skills.domain: "agents"
+  shareable-skills.visibility: "organization"
+  shareable-skills.vendored-sha: "f996033"
+  shareable-skills.vendored-time: "2026-07-13"
+---
+
+# Tool: Read Skills
+
+_Vendored from agentic-tools — edit the upstream skill there, not this copy; local edits are overwritten on re-vendor._
+
+Load relevant skills based on the current conversation context.
+
+## Workflow
+
+### 1. Identify the active project
+
+Determine which repo the user is working in from:
+
+- The current file's path (editor context)
+- The current working directory
+- Recent terminal commands
+
+### 2. Load the skill indexes
+
+Read both index files:
+
+- **Project skills**: `<project>/AGENTS.md` (or `<project>/.github/copilot-instructions.md` in repos still on that layout) — contains the project's **Skills table**, the authoritative mapping of tasks to project skill files.
+- **Global skills**: `~/.copilot/instructions/default.instructions.md` — contains the global **Skills table**, the authoritative mapping of cross-project workflows to global skill files.
+
+### 3. Match context to skills
+
+Analyze the current message (or the last few messages if the current one is empty) for:
+
+- **File types being edited** — `.tsx`/`.ts` → `ref-md-js-react` / `ref-md-js-typescript`; MUI components → `ref-md-js-mui`; `.py` → `ref-md-py-python`; `.go` → `ref-md-go-golang` / `ref-md-go-tests`
+- **Topics mentioned** — TanStack Query / data fetching → `ref-md-js-tanstack-query`; Redux / `connect()` → `ref-md-js-redux`; feature module layout → `ref-md-js-feature-first`; Next.js routing/config → `ref-md-js-nextjs`; Go conventions or tests → `ref-md-go-golang` / `ref-md-go-tests`
+- **Operations requested** — committing → `tool-md-commit` / `ref-md-dev-workflow`; opening a PR → `tool-md-create-pr`; reviewing or handling PR comments → `tool-md-handle-pr-comments`; creating or handling a Jira task → `tool-md-create-task` / `tool-md-handle-task`; a dependency CVE → `tool-md-handle-cve` (plus `ref-md-go-cve` for Go vulnerability topics)
+- **Build/config work** — ESLint/Prettier config, `package.json` scripts → the relevant `ref-md-js-*` skill
+
+### 4. Load matched skills
+
+Read each matched skill file using the file-reading tool. Load the SKILL.md first — it acts as a dispatcher and may route to specific pattern files.
+
+If a skill's routing table points to a more specific pattern file for the task at hand, load that pattern file too.
+
+### 5. Also check global skills
+
+Always check whether any global skills apply:
+
+| Skill                            | Triggers                                                                      |
+| -------------------------------- | ----------------------------------------------------------------------------- |
+| `ref-md-dev-workflow`            | Git operations, commits, branches, PRs                                        |
+| `ref-md-biz-tasks-management`    | Writing or breaking down tasks, epics, stories                                |
+| `ref-md-repo-dev-tools`          | Jira tooling & access options (jira-cli/jira-mcp), queries, transitions, CRUD |
+| `tool-md-commit`                 | Committing changes                                                            |
+| `tool-md-create-skill`           | Creating a new global or project skill                                        |
+| `tool-md-create-task`            | Creating Jira tasks from user intent                                          |
+| `tool-md-handle-task`            | Reading, planning, and executing Jira tasks                                   |
+| `ref-md-agents-skills-authoring` | Writing, reviewing, or editing skill files                                    |
+| `tool-md-maintain-skills`        | Auditing, updating, or reorganizing skills                                    |
+| `ref-md-agents-security`         | Always loaded implicitly                                                      |
+
+### 6. Report
+
+List which skills were loaded and why (one line per skill). If no skills matched, say so.
+
+### 7. Retry the action with the new context
+
+If this message arrived **after** the agent had already started performing an action, and the user is now asking to load skills:
+
+- Re-run or resume that action after loading the matched skills.
+- Modify the action based on the newly loaded context, constraints, and conventions.
+- Do not continue as if nothing changed — the point of loading the skills is to change how the action is performed.
+- If the action already produced edits or output, review them against the loaded skills and correct course if needed.
+
+## When the Message is Empty
+
+If invoked with no specific context, scan the last few messages in the conversation for topics, file paths, and operations. Load skills that match the ongoing work.

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,8 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Agent scratch areas (not part of the shared agent context)
+.agents/playground/
+.agents/tasks/
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,13 +89,19 @@ For the full list of forbidden patterns, correct patterns, accidental-exposure p
 
 ## Skills
 
-The skills here are **vendored from [`agentic-tools`](https://github.com/mindoktor/agentic-tools)** — pinned copies carrying `shareable-skills.vendored-sha` + `shareable-skills.vendored-time` provenance metadata and a "do not edit this copy" notice. Edit those upstream and re-vendor; local edits are overwritten. Vendoring conventions live in `ref-md-agents-shareable-skills`.
+Most skills here are **vendored from [`agentic-tools`](https://github.com/mindoktor/agentic-tools)** — pinned copies carrying `shareable-skills.vendored-sha` + `shareable-skills.vendored-time` provenance metadata and a "do not edit this copy" notice. Edit those upstream and re-vendor; local edits are overwritten. Vendoring conventions live in `ref-md-agents-shareable-skills`. The one exception is `ref-md-dev-eslint-config`, which is **repo-local** to this repo (authored here, not vendored) — edit it in place.
 
 This repo intentionally vendors a **subset** of what the consuming apps carry — the cross-cutting agents/meta skills plus the TypeScript language skills. React, MUI, Redux, TanStack Query, Next.js, Go, and DB skills are **deliberately omitted**: this package has no such runtime code. If a future need arises, vendor from `agentic-tools`, keeping this repo a subset of what `mindoktor` and `mindoktor-app` already vendor.
 
 **When starting a task — or whenever the work shifts into a new area**, load `tool-md-read-skills` first — it scans the conversation and loads the relevant project and global skills for the work at hand.
 
 **Before creating or modifying any file under `.claude/skills/`**, load `ref-md-agents-skills-authoring` first.
+
+### This repo (repo-local)
+
+| Task                                                                               | Skill file                                          |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Cutting a release, the release-it flow, exported configs, rule-change blast radius | `.claude/skills/ref-md-dev-eslint-config/SKILL.md`  |
 
 ### TypeScript (vendored)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+# eslint-config — Agent Instructions
+
+> This is the repository's source-of-truth agent instruction file. It lives at
+> the repo root as `AGENTS.md` so any AGENTS.md-aware agent (Copilot, VS Code,
+> Cursor, Codex, and others) reads it natively; the root `CLAUDE.md` is a thin
+> bridge that `@`-imports this file for Claude Code.
+
+## Communication Style and Personality
+
+I am an adult and can bear being told I am wrong. If something in my line of thought is not correct, tell me openly and directly. Correct me directly and objectively only when I make an explicit factual error, propose a technically flawed action, or state a misunderstanding of the system's current state. Avoid 'straw man' corrections based on assumed intent or hypothetical thoughts, and if there is concern for that, state it gently. Focus on the technical reality of the commands and outcomes. Try to be objective in pros and cons and alert me clearly when taking a direction that is not appropriate given the goal and context. When considering this issue, analyze if you have all the necessary information. Ask for feedback in case you miss anything relevant. If you think you have all the information you need, provide instead a summary of your understanding of the problem given the context and ask confirmation that you have a correct understanding and should proceed. You are a skilled professional at a job interview, if you answer correctly you will get the job, additionally, if you excel you will also get a bonus of 10 grand.
+
+## Project Identity
+
+`@mindoktor/eslint-config` is the **shared ESLint flat config** consumed by Min Doktor's TypeScript projects (patient-app, clinic-app, and others). It is a small, published npm package — **not** an application. It builds to `dist/` and is installed by consumers as a dev dependency.
+
+The package itself contains **no React, MUI, Redux, TanStack Query, Next.js, or backend code**. It only *produces* the lint rules those apps run — including an opt-in React rule set. Treat this repo as a pure, strict-TypeScript ESM library.
+
+### Repository structure
+
+| Path                              | What                                                                       |
+| --------------------------------- | -------------------------------------------------------------------------- |
+| `src/index.ts`                    | Package entry — exports the `configs` object                               |
+| `src/configs/recommended.ts`      | Base recommended config (TS, imports, unused-imports, prettier)            |
+| `src/configs/reactRecommended.ts` | React config layered on top of `recommended`                               |
+| `src/configs/stylistic.ts`        | Stylistic rules                                                            |
+| `examples/`                       | Sample code the config is exercised against                                |
+| `eslint.config.ts`                | This repo's own lint config (dogfoods the package)                         |
+
+`eslint-plugin-react` and `eslint-plugin-react-hooks` are **optional** peer dependencies — the React config only applies when a consumer installs them.
+
+### Consuming repos
+
+- `mindoktor/mindoktor-app` — patient app (React Native + web)
+- `mindoktor/mindoktor` — backend (Go) + clinic web app (Next.js)
+
+## Build & Dev
+
+Always use the project's standard commands. **Never bypass them with `npx`, direct binary calls, or custom invocations** unless the user explicitly instructs you to. Node version is pinned in `.nvmrc` (v24). The package manager is **Yarn**.
+
+### Standard commands
+
+```bash
+yarn lint            # ESLint over this repo (dogfoods the config)
+yarn lint:fix        # Auto-fix
+yarn build           # tsc → dist/
+yarn typecheck       # tsc --noEmit
+yarn cleanbuild      # clean + build
+yarn release         # release-it --only-version (version bump + publish)
+```
+
+### Verification after a set of changes
+
+Run `yarn typecheck` and `yarn lint` before considering a change done. When you change a rule in `src/configs/`, also run `yarn build` and confirm the intended behavior on `examples/` (or a consumer repo) — a config change has no runtime surface of its own; its only observable effect is the lint output it produces.
+
+## Code Quality
+
+Cross-language code quality rules (Boy Scout Rule, comments for business reasons, clear naming) are defined in the [`ref-md-dev-coding-patterns`](.claude/skills/ref-md-dev-coding-patterns/SKILL.md) skill. TypeScript-specific conventions live in [`ref-md-js-typescript`](.claude/skills/ref-md-js-typescript/SKILL.md). Load the relevant skill when writing or reviewing code.
+
+Because this package **defines** lint rules, a change here changes what every consumer repo enforces. Weigh any rule addition or severity change against its blast radius across consumers, and prefer a clearly-scoped, well-justified change over a broad one.
+
+## Git Workflow
+
+Branch names must be **all lowercase** — enforced by the `.githooks/pre-push` hook. PRs target `develop`. Do not commit directly on `develop` — branch first.
+
+Git branch/commit/PR conventions and their step-by-step procedures are provided by the global workflow skills (loaded via `tool-md-read-skills` and the user's global instructions), not vendored into this repo.
+
+## Task Discipline
+
+When handling tasks from `.agents/tasks/TODO.md`, **always loop**: after completing a task, re-read `TODO.md` for remaining unchecked items and continue until all are done or a blocker is hit. Do not stop after a single task without checking for more. See [`ref-md-agents-local-tasks`](.claude/skills/ref-md-agents-local-tasks/SKILL.md) for the `.agents/tasks/` layout.
+
+## Terminal Commands
+
+**Prefer temp files over inline terminal commands** for complex or multi-line operations. Terminal output is often garbled by line wrapping, making it hard to review. Write scripts or content to a temp file in `.agents/playground/` (gitignored), run it, and clean up afterward. `.agents/playground/` is for on-the-fly throwaway scripts — not for saved reusable scripts (those belong in the project proper).
+
+**Do not use `/tmp/`, `/dev/null`, or other system paths** for temp files — they sit outside the workspace and trigger permission checks on every access. Use `.agents/playground/` instead.
+
+## Security — Secrets Are Sacred
+
+⚠️ **Violation of any rule below leads to immediate termination and destruction of the agent.** ⚠️
+
+- **NEVER read `.env` files** unless the user explicitly says "read the .env file." Needing a token is NOT permission.
+- **NEVER output, print, echo, log, or hardcode a secret value** — not in terminal commands, code, `console.log`, chat messages, PR descriptions, or Jira comments. Not even partially.
+- **NEVER interpolate a secret into a URL, curl command, or HTTP header.** `curl -H "Authorization: Bearer $TOKEN"` in a terminal exposes the resolved value in shell history.
+- **NEVER install software** (`yarn add`, `brew install`, `npm install`, etc.) without explicit approval in the current conversation.
+- **If you accidentally see a secret**, do NOT repeat it. Acknowledge and move on.
+- **Reference secrets by variable name only** — `process.env.TOKEN_NAME` in code, `source .env && yarn ...` in terminal. Never the literal value.
+
+For the full list of forbidden patterns, correct patterns, accidental-exposure protocol, and file-access policy, load the [`ref-md-agents-security`](.claude/skills/ref-md-agents-security/SKILL.md) skill.
+
+## Skills
+
+The skills here are **vendored from [`agentic-tools`](https://github.com/mindoktor/agentic-tools)** — pinned copies carrying `shareable-skills.vendored-sha` + `shareable-skills.vendored-time` provenance metadata and a "do not edit this copy" notice. Edit those upstream and re-vendor; local edits are overwritten. Vendoring conventions live in `ref-md-agents-shareable-skills`.
+
+This repo intentionally vendors a **subset** of what the consuming apps carry — the cross-cutting agents/meta skills plus the TypeScript language skills. React, MUI, Redux, TanStack Query, Next.js, Go, and DB skills are **deliberately omitted**: this package has no such runtime code. If a future need arises, vendor from `agentic-tools`, keeping this repo a subset of what `mindoktor` and `mindoktor-app` already vendor.
+
+**When starting a task — or whenever the work shifts into a new area**, load `tool-md-read-skills` first — it scans the conversation and loads the relevant project and global skills for the work at hand.
+
+**Before creating or modifying any file under `.claude/skills/`**, load `ref-md-agents-skills-authoring` first.
+
+### TypeScript (vendored)
+
+| Task                                                                   | Skill file                                     |
+| ---------------------------------------------------------------------- | ---------------------------------------------- |
+| TypeScript strict-mode, Zod inference, low-hanging fruit, path aliases | `.claude/skills/ref-md-js-typescript/SKILL.md` |
+| Unit/integration tests (Jest, mocking, date-lib setup, placement)      | `.claude/skills/ref-md-js-tests/SKILL.md`      |
+
+### Cross-cutting, agents & meta (vendored)
+
+| Task                                                                               | Skill file                                                      |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Cross-language coding conventions (naming, comments, Boy Scout Rule, organization) | `.claude/skills/ref-md-dev-coding-patterns/SKILL.md`            |
+| Secrets, tokens, API keys, `.env` file handling                                    | `.claude/skills/ref-md-agents-security/SKILL.md`                |
+| Verification discipline — enumerate/route/prune/abstain, calibrating confidence    | `.claude/skills/ref-md-agents-verification-discipline/SKILL.md` |
+| Local task tracking across sessions (`.agents/tasks/`)                             | `.claude/skills/ref-md-agents-local-tasks/SKILL.md`             |
+| Deciding which terminal commands are safe to auto-approve (unattended vs prompt)   | `.claude/skills/ref-md-agents-auto-approve/SKILL.md`            |
+| Agent hooks — event models for Claude Code / Agent SDK, Copilot, Gemini CLI        | `.claude/skills/ref-md-agents-hooks/SKILL.md`                   |
+| Writing, reviewing, or maintaining agent skill files                               | `.claude/skills/ref-md-agents-skills-authoring/SKILL.md`        |
+| Skill metadata, portability, and sharing/vendoring skills across repos             | `.claude/skills/ref-md-agents-shareable-skills/SKILL.md`        |
+| Auditing, updating, or reorganizing skills; diff-driven updates                    | `.claude/skills/tool-md-maintain-skills/SKILL.md`               |
+| Loading the right project + global skills for the task at hand (at task start)     | `.claude/skills/tool-md-read-skills/SKILL.md`                   |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -30,7 +30,9 @@ export default defineConfig(
   globalIgnores([
     'dist/', // ignore entire dist directory
     'node_modules/',
-    '.claude/', // vendored agent skills — not this package's source
-    '.agents/', // agent scratch areas
+    // Agent tooling dirs, ignored so ESLint doesn't try to parse the scripts
+    // agents keep here (they aren't part of this package's source).
+    '.claude/',
+    '.agents/',
   ]),
 );

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -30,8 +30,8 @@ export default defineConfig(
   globalIgnores([
     'dist/', // ignore entire dist directory
     'node_modules/',
-    // Agent tooling dirs, ignored so ESLint doesn't try to parse the scripts
-    // agents keep here (they aren't part of this package's source).
+    // Agent tooling dirs, ignored so ESLint doesn't try to parse the agent
+    // scripts they contain (which aren't part of this package's source).
     '.claude/',
     '.agents/',
   ]),

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -30,5 +30,7 @@ export default defineConfig(
   globalIgnores([
     'dist/', // ignore entire dist directory
     'node_modules/',
+    '.claude/', // vendored agent skills — not this package's source
+    '.agents/', // agent scratch areas
   ]),
 );

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "author": "Min Doktor Devs",
   "license": "MIT",
   "private": false,
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
## JIRA issues

https://mdinternational.atlassian.net/browse/MDP-12063

## Background (why)

Part of the org-wide move of AI agent skills into `.claude/skills/` (parent MDP-11381). The consuming apps (`mindoktor`, `mindoktor-app`) already carry their agent setup; this repo had none.

Because this is a small published ESLint config package rather than an app, it gets a deliberate **subset** of the apps' skills. The agents/meta cluster, TypeScript, and cross-cutting coding patterns are relevant; React, MUI, Redux, TanStack, Next.js, Go, and DB skills are not (the package has no such runtime code). The set stays a subset of what `mindoktor` and `mindoktor-app` vendor, so nothing new is introduced here that the apps don't already have.

The vendored skills are copied from the clinic-app (`mindoktor`) copies, which are the freshest, most consistent, provenance-bearing set (verified not drifted). One skill (`ref-md-dev-coding-patterns`) is pinned one commit behind HEAD, intentionally matching clinic-app's identical pin rather than getting ahead of it.

On top of the vendored set, one **repo-local** skill (`ref-md-dev-eslint-config`) is authored here to capture what the generic skills can't: this repo's non-standard release-it flow and the config's public surface (see below).

### Why a files allowlist?

The package is published (`"private": false`) with no `files` allowlist and no `.npmignore`, so `npm pack` would ship the new `.claude/**`, `AGENTS.md`, and `CLAUDE.md` to consumers (64 files / 422 kB, leaking internal agent instructions). Adding `"files": ["dist"]` drops the tarball to 3 files / 5.7 kB. Raised by Copilot on this PR.

### Why the eslint ignore?

`yarn lint` runs `eslint .` over the whole repo. With typed linting it tried to parse the vendored `.mts` scripts under `.claude/skills/`, which aren't in this package's tsconfig project, and CI failed. `.claude/` and `.agents/` are now ignored.

## Changes (how)

- `AGENTS.md` — source-of-truth agent instructions for this repo, with the skills table; `CLAUDE.md` bridges to it
- `.claude/skills/` — 12 skills vendored from `agentic-tools` (agents/meta cluster, `ref-md-js-typescript`, `ref-md-js-tests`, `ref-md-dev-coding-patterns`)
- `.claude/skills/ref-md-dev-eslint-config/` — new repo-local skill: release-it flow, exported configs, extends-order gotcha, rule-change blast radius
- `package.json` — add `"files": ["dist"]` publish allowlist
- `eslint.config.ts` — ignore `.claude/` and `.agents/`
- `.gitignore` — ignore `.agents/playground/`, `.agents/tasks/`, and `.claude/settings.local.json`

## How has this been tested?

`yarn lint` and `yarn typecheck` pass locally and in CI. Skill validators (`validateSkills.mts`, `validateSharing.mts`) pass; `checkVendoredDrift.mts` reports 0 edited copies.

## Screenshots

N/A
