### PR TITLE
chore: bump eslint-plugin-react-hooks peer floor to >=7

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-import": ">=2",
     "eslint-plugin-prettier": ">=5",
     "eslint-plugin-react": ">=7",
-    "eslint-plugin-react-hooks": ">=5.2.0",
+    "eslint-plugin-react-hooks": ">=7",
     "eslint-plugin-simple-import-sort": ">=12",
     "eslint-plugin-unused-imports": ">=4",
     "prettier": ">=3",


### PR DESCRIPTION
## JIRA issues

<!-- No dedicated ticket; follow-up to the react-hooks 7 upgrade (PR #17). -->

N/A — follow-up to the react-hooks 7 upgrade ([#17](https://github.com/mindoktor/eslint-config/pull/17)).

## Background (why)

The react-hooks 7 upgrade (#17, released in 3.0.0) changed how the config wires the plugin: it now registers the plugin object directly and enables only `rules-of-hooks` + `exhaustive-deps`. That PR widened the peer from the invalid `">=5.2 & <6"` to `">=5.2.0"`, which *permits* v7 but still declares support down to 5.2.

Since the config is built and tested against v7, a consumer resolving an older react-hooks major (5.x/6.x) against the v7-shaped wiring could hit subtle plugin-shape mismatches. Declaring `>=7` makes the supported baseline honest and matches the bare `>=<major>` style of the sibling peers (`eslint >=9`, `typescript-eslint >=8`, …).

The plugin stays an **optional** peer, so consumers not using the React config are unaffected.

## Changes (how)

- `peerDependencies.eslint-plugin-react-hooks`: `">=5.2.0"` → `">=7"`.

## How has this been tested?

`yarn typecheck` / `yarn lint` / `yarn build` pass. Peer-only change — `yarn.lock` is untouched (dev dep already `^7.1.1`).

## Screenshots

N/A.

## Checklist

<!--
AI agents: before this box is checked, assess whether this PR warrants running
`/tool-md-maintain-skills`. It is needed when the change introduces or alters something a
skill documents — a convention, command, file layout, API, or recurring pattern — so the
skill should be updated to match. If it does, recommend running it to the user (naming the
affected skill) before merge. If the change touches nothing a skill documents, the step can
be skipped. Humans can ignore this block.
-->

- [x] I checked whether this change affects any agent skills and ran `/tool-md-maintain-skills` if needed — a single peer-range bump; the `ref-md-dev-eslint-config` skill documents the release model and blast radius, not individual peer values, so no skill update is needed.
